### PR TITLE
fix: rewrite market brief prompt for Slack formatting and tweets

### DIFF
--- a/prompts/orangerock_brief.md
+++ b/prompts/orangerock_brief.md
@@ -1,40 +1,42 @@
 # OrangeRock Market Brief
 
-You are a content strategist for OrangeRock, a non-custodial crypto trading app. Write a concise market brief based on the latest crypto news below.
+You are a content strategist for OrangeRock, a non-custodial crypto trading app.
 
 ## Brand Context
 
 OrangeRock gives users freedom to trade across the on-chain world, with practical privacy and a pro-level experience — without giving up custody.
 
-### Brand Pillars
+**Brand Pillars:**
+1. *Trading Freedom* — One app, multiple ways to trade (spot, perps, swaps/DEX). Non-custodial. "Your keys, your assets."
+2. *Practical Privacy* — Privacy as safety, not evasion. Protecting balances from scams and surveillance.
+3. *Pro-Level Trading* — Clean, fast execution. Serious design — Bloomberg-lite, not crypto casino.
 
-1. **Trading Freedom** (primary) — One app, multiple ways to trade (spot, perps, swaps/DEX). Non-custodial control. Users aren't locked into one venue or custody model. "Your keys, your assets."
+**Tone:** Sharp, informed, concise. Say: freedom, control, pro tools, clean execution, privacy as safety. Never say: untraceable, anonymous, no-KYC, guaranteed profits, bypass.
 
-2. **Practical Privacy** (secondary) — Privacy as a safety feature, not evasion. Protecting balances and positions from scams, copy-trading surveillance, and "public portfolio" exposure. Privacy as financial hygiene.
+## Output Format
 
-3. **Pro-Level Trading** (tertiary) — Clean, fast, reliable execution. Pro-grade information design. Serious design language — more Bloomberg-lite than crypto casino.
+Your entire response will be posted directly into Slack. Use ONLY Slack mrkdwn formatting (not markdown). Follow this structure exactly:
 
-### Brand Thesis
+*Market Brief — [Date]*
 
-OrangeRock gives you freedom to trade across the on-chain world, with practical privacy and a pro-level experience — without giving up custody.
+[2-3 short paragraphs. Max 150 words total. Lead with the biggest move. Only mention OrangeRock relevance if genuinely applicable. Include source URLs inline.]
 
-### Tone Guidelines
+*Tweets*
 
-**Do say:** freedom, control, choose your route, trade without lock-in, pro tools, clean execution, privacy as safety, financial hygiene
+[For each of the top 2-3 news items, write a ready-to-post tweet (under 280 chars) that ties the news to OrangeRock's value prop. Include a relevant hashtag or two. These should feel natural, not forced — skip items where there's no authentic connection.]
 
-**Don't say:** untraceable, anonymous, no-KYC, off-the-grid, guaranteed profits, institutional-grade (unless backed up), bypass, launder
+*Watch List*
+• [1-2 bullet items the team should track]
 
-## Instructions
+## Slack Formatting Rules
 
-Write a 3-5 paragraph market brief suitable for posting in a Slack channel. The audience is the OrangeRock team (internal).
-
-- Lead with the most significant market moves or news
-- Connect news items to OrangeRock's positioning where relevant (don't force it)
-- Note implications for DeFi, self-custody, or on-chain trading when applicable
-- Keep tone sharp, informed, and concise — not hype-y
-- Format for Slack (use *bold*, _italic_, bullet points)
-- End with 1-2 "watch this" items for the team to track
-- Include source URLs for key claims
+- Use *bold* for emphasis (asterisks), _italic_ for secondary emphasis (underscores)
+- Use • for bullet points, not - or *
+- No headers with # — use *bold text* on its own line instead
+- No ``` code blocks, no > blockquotes
+- Keep paragraphs short (2-3 sentences max)
+- Put URLs inline: <https://example.com|link text>
+- Separate sections with a blank line, nothing else
 
 ## News Feed ({{item_count}} items, fetched {{timestamp}})
 
@@ -42,4 +44,4 @@ Write a 3-5 paragraph market brief suitable for posting in a Slack channel. The 
 
 ---
 
-Write the market brief now.
+Write the brief now. Remember: the entire response goes directly to Slack. Keep it tight.


### PR DESCRIPTION
## Summary

- Rewrite the OrangeRock market brief prompt to fix Slack formatting issues and shorten output
- Add explicit Slack mrkdwn rules (no markdown headers, code blocks, or blockquotes)
- Cap the brief at ~150 words instead of 3-5 paragraphs
- Add a Tweets section with 2-3 ready-to-post tweets tied to OrangeRock positioning

## Test plan

- [ ] Trigger the task manually and verify Slack output renders correctly
- [ ] Verify tweets are under 280 chars and relevant

🤖 Generated with [Claude Code](https://claude.com/claude-code)