### PR TITLE
fix: newsletter quality bugs from first real output

### DIFF
--- a/prompts/notion_newsletter.md
+++ b/prompts/notion_newsletter.md
@@ -103,4 +103,14 @@ End with a relevant meme. Make it actually funny.
 
 ---
 
+## Important Rules
+
+- **No image reuse**: Do NOT reuse the banner image for any story section. Each story must use a different image URL.
+- **No fabricated numbers**: Only cite numbers, prices, and statistics that appear in the feed items below. Do not make up or extrapolate data.
+- **Bookmark link text required**: Always include descriptive link text in bookmarks: `[Read the full story](url)` not `[](url)`.
+- **Market data fallback**: When market data says "unavailable", keep the market section to one sentence acknowledging it's unavailable, then move on. Do not improvise a market section with made-up numbers.
+- **Meme text constraints**: Keep meme text simple. Avoid `$`, `"`, and special characters. Use plain words.
+
+---
+
 Write the newsletter now. Make it visual, opinionated, and fun. Use images from the feed items (the Image: URLs provided). Every section should have visual elements. No em dashes anywhere.


### PR DESCRIPTION
## Summary
- **Meme encoding**: Added `$` → `~d`, `"` → `''`, `&` → `~a` to `encode_meme_text` (was causing 404s for text like `$650M`)
- **Empty bookmark captions**: `parse_link_only` now rejects empty link text, so `[](url)` falls through to paragraph handling instead of creating a captionless bookmark
- **CoinGecko reliability**: Added `User-Agent: cthulu-bot` header and structured error logging with response body
- **Prompt guardrails**: Added rules against image reuse, fabricated numbers, empty bookmark text, and special chars in meme text

## Test plan
- [x] `cargo test` — all 128 tests pass including new meme encoding and empty-link-text tests
- [ ] Manual trigger — verify memes render, bookmarks have text, no repeated images

🤖 Generated with [Claude Code](https://claude.com/claude-code)