### PR TITLE
feat: crypto news pipeline + web scraper + filters + structured logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "bytestring",
- "derive_more",
+ "derive_more 2.1.1",
  "encoding_rs",
  "foldhash",
  "futures-core",
@@ -127,7 +127,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "cfg-if",
- "derive_more",
+ "derive_more 2.1.1",
  "encoding_rs",
  "foldhash",
  "futures-core",
@@ -335,6 +335,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +426,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cthulu"
 version = "0.1.0"
 dependencies = [
@@ -435,6 +464,7 @@ dependencies = [
  "futures",
  "hyper",
  "reqwest",
+ "scraper",
  "sentry",
  "serde",
  "serde_json",
@@ -446,6 +476,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "tracing-tree",
  "uuid",
 ]
 
@@ -476,6 +507,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -548,6 +590,27 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
+name = "ego-tree"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "encoding_rs"
@@ -652,6 +715,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +811,24 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -841,6 +932,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-link",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "match_token",
 ]
 
 [[package]]
@@ -1234,6 +1337,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "match_token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,6 +1440,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -1631,6 +1771,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +1885,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,7 +1948,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1793,12 +1991,21 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1808,8 +2015,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -2029,6 +2242,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527e65d9d888567588db4c12da1087598d0f6f8b346cc2c5abc91f05fc2dffe2"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,6 +2277,25 @@ checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more 0.99.20",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -2124,7 +2371,7 @@ version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0b1e7ca40f965db239da279bf278d87b7407469b98835f27f0c8e59ed189b06"
 dependencies = [
- "rand",
+ "rand 0.9.2",
  "sentry-types",
  "serde",
  "serde_json",
@@ -2198,7 +2445,7 @@ checksum = "567711f01f86a842057e1fc17779eba33a336004227e1a1e7e6cc2599e22e259"
 dependencies = [
  "debugid",
  "hex",
- "rand",
+ "rand 0.9.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2283,6 +2530,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,6 +2608,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,6 +2680,17 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -2744,6 +3036,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-tree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac87aa03b6a4d5a7e4810d1a80c19601dbe0f8a837e9177f23af721c7ba7beec"
+dependencies = [
+ "nu-ansi-term",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2769,6 +3073,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ dotenvy = "0.15.7"
 chrono = { version = "0.4.41", features = ["serde"] }
 uuid = { version = "1.17.0", features = ["v4"] }
 feed-rs = "2.3"
+scraper = "0.23"
 croner = "2"
 dirs = "5"
 tower-http = { version = "0.6", features = ["cors"] }
@@ -34,6 +35,7 @@ tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt", "json", "time", "local-time"] }
 sentry = { version = "0.46.0", features = ["tower-axum-matched-path", "tracing", "logs"] }
+tracing-tree = "0.4.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/cthulu-studio/src/components/Canvas.tsx
+++ b/cthulu-studio/src/components/Canvas.tsx
@@ -19,6 +19,7 @@ import "@xyflow/react/dist/style.css";
 import TriggerNode from "./NodeTypes/TriggerNode";
 import SourceNode from "./NodeTypes/SourceNode";
 import ExecutorNode from "./NodeTypes/ExecutorNode";
+import FilterNode from "./NodeTypes/FilterNode";
 import SinkNode from "./NodeTypes/SinkNode";
 import type { Flow, FlowNode, FlowEdge } from "../types/flow";
 import { log } from "../api/logger";
@@ -26,6 +27,7 @@ import { log } from "../api/logger";
 const rfNodeTypes: NodeTypes = {
   trigger: TriggerNode,
   source: SourceNode,
+  filter: FilterNode,
   executor: ExecutorNode,
   sink: SinkNode,
 };

--- a/cthulu-studio/src/components/NodeTypes/FilterNode.tsx
+++ b/cthulu-studio/src/components/NodeTypes/FilterNode.tsx
@@ -1,0 +1,21 @@
+import { Handle, Position } from "@xyflow/react";
+
+interface FilterNodeData {
+  label: string;
+  kind: string;
+  config: Record<string, unknown>;
+}
+
+export default function FilterNode({ data }: { data: FilterNodeData }) {
+  return (
+    <div className="custom-node">
+      <Handle id="in" type="target" position={Position.Left} />
+      <div className="node-header">
+        <span className="node-type-badge filter">Filter</span>
+      </div>
+      <div className="node-label">{data.label}</div>
+      <div className="node-kind">{data.kind}</div>
+      <Handle id="out" type="source" position={Position.Right} />
+    </div>
+  );
+}

--- a/cthulu-studio/src/components/PropertyPanel.tsx
+++ b/cthulu-studio/src/components/PropertyPanel.tsx
@@ -123,6 +123,23 @@ function renderConfigFields(
               onChange={(e) => onChange("limit", parseInt(e.target.value) || 10)}
             />
           </div>
+          <div className="form-group">
+            <label>Keywords (comma separated, optional)</label>
+            <input
+              value={
+                Array.isArray(config.keywords)
+                  ? (config.keywords as string[]).join(", ")
+                  : ""
+              }
+              onChange={(e) =>
+                onChange(
+                  "keywords",
+                  e.target.value.split(",").map((s) => s.trim()).filter(Boolean)
+                )
+              }
+              placeholder="bitcoin, crypto, regulation"
+            />
+          </div>
         </>
       );
     case "github-merged-prs":
@@ -184,6 +201,154 @@ function renderConfigFields(
               }
               placeholder="Bash, Read, Grep, Glob"
             />
+          </div>
+          <div className="form-group">
+            <label>System Prompt</label>
+            <textarea
+              value={(config.append_system_prompt as string) || ""}
+              onChange={(e) =>
+                onChange(
+                  "append_system_prompt",
+                  e.target.value || null
+                )
+              }
+              placeholder="Additional instructions appended to Claude's system prompt"
+              rows={4}
+            />
+          </div>
+        </>
+      );
+    case "web-scrape":
+      return (
+        <>
+          <div className="form-group">
+            <label>Page URL</label>
+            <input
+              value={(config.url as string) || ""}
+              onChange={(e) => onChange("url", e.target.value)}
+              placeholder="https://example.gov/news"
+            />
+          </div>
+          <div className="form-group">
+            <label>Keywords (comma separated)</label>
+            <input
+              value={
+                Array.isArray(config.keywords)
+                  ? (config.keywords as string[]).join(", ")
+                  : ""
+              }
+              onChange={(e) =>
+                onChange(
+                  "keywords",
+                  e.target.value.split(",").map((s) => s.trim()).filter(Boolean)
+                )
+              }
+              placeholder="bitcoin, crypto, regulation"
+            />
+          </div>
+        </>
+      );
+    case "web-scraper":
+      return (
+        <>
+          <div className="form-group">
+            <label>Page URL</label>
+            <input
+              value={(config.url as string) || ""}
+              onChange={(e) => onChange("url", e.target.value)}
+              placeholder="https://www.sec.gov/news/pressreleases"
+            />
+          </div>
+          <div className="form-group">
+            <label>Base URL</label>
+            <input
+              value={(config.base_url as string) || ""}
+              onChange={(e) => onChange("base_url", e.target.value || null)}
+              placeholder="https://www.sec.gov"
+            />
+          </div>
+          <div className="form-group">
+            <label>Items Selector</label>
+            <input
+              value={(config.items_selector as string) || ""}
+              onChange={(e) => onChange("items_selector", e.target.value)}
+              placeholder="div.press-release"
+            />
+          </div>
+          <div className="form-group">
+            <label>Title Selector</label>
+            <input
+              value={(config.title_selector as string) || ""}
+              onChange={(e) => onChange("title_selector", e.target.value || null)}
+              placeholder="h3 a"
+            />
+          </div>
+          <div className="form-group">
+            <label>URL Selector</label>
+            <input
+              value={(config.url_selector as string) || ""}
+              onChange={(e) => onChange("url_selector", e.target.value || null)}
+              placeholder="h3 a"
+            />
+          </div>
+          <div className="form-group">
+            <label>Summary Selector</label>
+            <input
+              value={(config.summary_selector as string) || ""}
+              onChange={(e) => onChange("summary_selector", e.target.value || null)}
+              placeholder="p.summary"
+            />
+          </div>
+          <div className="form-group">
+            <label>Limit</label>
+            <input
+              type="number"
+              value={(config.limit as number) || 10}
+              onChange={(e) => onChange("limit", parseInt(e.target.value) || 10)}
+            />
+          </div>
+        </>
+      );
+    case "keyword":
+      return (
+        <>
+          <div className="form-group">
+            <label>Keywords (comma separated)</label>
+            <input
+              value={
+                Array.isArray(config.keywords)
+                  ? (config.keywords as string[]).join(", ")
+                  : ""
+              }
+              onChange={(e) =>
+                onChange(
+                  "keywords",
+                  e.target.value.split(",").map((s) => s.trim()).filter(Boolean)
+                )
+              }
+              placeholder="bitcoin, crypto, sec, etf"
+            />
+          </div>
+          <div className="form-group">
+            <label>Require All</label>
+            <select
+              value={config.require_all ? "true" : "false"}
+              onChange={(e) => onChange("require_all", e.target.value === "true")}
+            >
+              <option value="false">Any keyword (OR)</option>
+              <option value="true">All keywords (AND)</option>
+            </select>
+          </div>
+          <div className="form-group">
+            <label>Match Field</label>
+            <select
+              value={(config.field as string) || "title_or_summary"}
+              onChange={(e) => onChange("field", e.target.value)}
+            >
+              <option value="title_or_summary">Title or Summary</option>
+              <option value="title">Title only</option>
+              <option value="summary">Summary only</option>
+            </select>
           </div>
         </>
       );

--- a/cthulu-studio/src/components/Sidebar.tsx
+++ b/cthulu-studio/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ interface SidebarProps {
 const typeColors: Record<string, string> = {
   trigger: "var(--trigger-color)",
   source: "var(--source-color)",
+  filter: "#ffa657",
   executor: "var(--executor-color)",
   sink: "var(--sink-color)",
 };
@@ -16,6 +17,7 @@ export default function Sidebar({ nodeTypes, onGrab }: SidebarProps) {
   const grouped = {
     trigger: nodeTypes.filter((n) => n.node_type === "trigger"),
     source: nodeTypes.filter((n) => n.node_type === "source"),
+    filter: nodeTypes.filter((n) => n.node_type === "filter"),
     executor: nodeTypes.filter((n) => n.node_type === "executor"),
     sink: nodeTypes.filter((n) => n.node_type === "sink"),
   };
@@ -23,7 +25,7 @@ export default function Sidebar({ nodeTypes, onGrab }: SidebarProps) {
   return (
     <div className="node-palette">
       <h3>Add Nodes</h3>
-      {(["trigger", "source", "executor", "sink"] as const).map((type) => (
+      {(["trigger", "source", "filter", "executor", "sink"] as const).map((type) => (
         <div key={type}>
           {grouped[type].map((nt) => (
             <div

--- a/cthulu-studio/src/styles.css
+++ b/cthulu-studio/src/styles.css
@@ -311,6 +311,11 @@ button:disabled {
   color: var(--executor-color);
 }
 
+.custom-node .node-type-badge.filter {
+  background: rgba(255, 166, 87, 0.2);
+  color: #ffa657;
+}
+
 .custom-node .node-type-badge.sink {
   background: rgba(63, 185, 80, 0.2);
   color: var(--sink-color);

--- a/cthulu.toml
+++ b/cthulu.toml
@@ -131,6 +131,48 @@ bot_token_env = "SLACK_BOT_TOKEN"
 channel = "#the-ark"
 
 [[tasks]]
+name = "crypto-news-asia"
+executor = "claude-code"
+prompt = "prompts/crypto_breaking_news.md"
+permissions = []
+append_system_prompt = "You are a legitimate news research assistant. Your task is to analyze publicly available news articles and regulatory announcements, then produce a factual summary report. This is standard journalism research — summarize, cite sources, and draft neutral social media posts."
+
+[tasks.trigger.cron]
+schedule = "0 0 * * *"
+
+[[tasks.sources]]
+type = "rss"
+url = "https://cointelegraph.com/rss"
+limit = 15
+keywords = ["japan", "asia", "hong kong", "singapore", "korea", "china", "regulation", "fsa", "hkma", "mas"]
+
+[[tasks.sources]]
+type = "rss"
+url = "https://www.coindesk.com/arc/outboundfeeds/rss/"
+limit = 15
+keywords = ["japan", "asia", "hong kong", "singapore", "korea", "china", "regulation", "fsa", "hkma", "mas"]
+
+[[tasks.sources]]
+type = "web-scrape"
+url = "https://www.fsa.go.jp/en/news/index.html"
+keywords = ["crypto", "virtual asset", "digital asset", "stablecoin", "exchange"]
+
+[[tasks.sources]]
+type = "web-scrape"
+url = "https://www.hkma.gov.hk/eng/news-and-media/press-releases/"
+keywords = ["crypto", "virtual asset", "digital asset", "stablecoin", "cbdc"]
+
+[[tasks.sources]]
+type = "web-scrape"
+url = "https://www.mas.gov.sg/news"
+keywords = ["crypto", "digital asset", "token", "stablecoin", "blockchain"]
+
+[[tasks.sinks]]
+type = "notion"
+token_env = "NOTION_TOKEN"
+database_id = "30aac5ee2bf980728eaefe59a03ea940"
+
+[[tasks]]
 name = "product-updates"
 executor = "claude-code"
 prompt = "prompts/product_updates.md"

--- a/examples/crypto_news.toml
+++ b/examples/crypto_news.toml
@@ -1,0 +1,59 @@
+# Crypto News Pipeline
+# Monitors Google News RSS for crypto/Bitcoin news, drafts short posts,
+# and delivers to Notion for review.
+
+[server]
+port = 8081
+
+[[tasks]]
+name = "crypto-news"
+executor = "claude-api"
+prompt = "prompts/crypto_news_brief.md"
+
+[tasks.trigger.cron]
+schedule = "0 */4 * * *"
+
+# Google News RSS feeds for crypto topics
+[[tasks.sources]]
+type = "rss"
+url = "https://news.google.com/rss/search?q=bitcoin+OR+btc+OR+cryptocurrency&hl=en-US&gl=US&ceid=US:en"
+limit = 15
+
+[[tasks.sources]]
+type = "rss"
+url = "https://news.google.com/rss/search?q=SEC+crypto+OR+bitcoin+ETF+OR+CFTC+crypto&hl=en-US&gl=US&ceid=US:en"
+limit = 10
+
+[[tasks.sources]]
+type = "rss"
+url = "https://news.google.com/rss/search?q=stablecoin+regulation+OR+CBDC+OR+digital+dollar&hl=en-US&gl=US&ceid=US:en"
+limit = 5
+
+# SEC Press Releases (web scraper)
+[[tasks.sources]]
+type = "web-scraper"
+url = "https://www.sec.gov/news/pressreleases"
+base_url = "https://www.sec.gov"
+items_selector = "tr.pr-list-page-row"
+title_selector = "td.views-field-title a"
+url_selector = "td.views-field-title a"
+summary_selector = "td.views-field-field-description"
+date_selector = "td.views-field-field-publish-date time"
+limit = 10
+
+# CFTC Press Releases (web scraper)
+[[tasks.sources]]
+type = "web-scraper"
+url = "https://www.cftc.gov/PressRoom/PressReleases"
+base_url = "https://www.cftc.gov"
+items_selector = ".view-content .views-row"
+title_selector = ".views-field-title a"
+url_selector = ".views-field-title a"
+summary_selector = ".views-field-body"
+limit = 10
+
+# Notion as review sink (set NOTION_TOKEN and database ID in env)
+[[tasks.sinks]]
+type = "notion"
+token_env = "NOTION_TOKEN"
+database_id = "YOUR_DATABASE_ID_HERE"

--- a/examples/crypto_news_flow.json
+++ b/examples/crypto_news_flow.json
@@ -1,0 +1,104 @@
+{
+  "id": "crypto-news-pipeline",
+  "name": "Crypto News Pipeline",
+  "description": "Monitors crypto news from RSS and government sites, filters by keywords, drafts posts, delivers to Notion for review.",
+  "enabled": true,
+  "nodes": [
+    {
+      "id": "trigger-cron",
+      "node_type": "trigger",
+      "kind": "cron",
+      "config": {
+        "schedule": "0 */4 * * *",
+        "working_dir": "."
+      },
+      "position": { "x": 0, "y": 0 },
+      "label": "Every 4h"
+    },
+    {
+      "id": "source-google-news-btc",
+      "node_type": "source",
+      "kind": "rss",
+      "config": {
+        "url": "https://news.google.com/rss/search?q=bitcoin+OR+btc+OR+cryptocurrency&hl=en-US&gl=US&ceid=US:en",
+        "limit": 15
+      },
+      "position": { "x": 280, "y": -120 },
+      "label": "RSS: Google News (BTC)"
+    },
+    {
+      "id": "source-google-news-reg",
+      "node_type": "source",
+      "kind": "rss",
+      "config": {
+        "url": "https://news.google.com/rss/search?q=SEC+crypto+OR+bitcoin+ETF+OR+CFTC+crypto&hl=en-US&gl=US&ceid=US:en",
+        "limit": 10
+      },
+      "position": { "x": 280, "y": 0 },
+      "label": "RSS: Google News (Regulation)"
+    },
+    {
+      "id": "source-sec-press",
+      "node_type": "source",
+      "kind": "web-scraper",
+      "config": {
+        "url": "https://www.sec.gov/news/pressreleases",
+        "base_url": "https://www.sec.gov",
+        "items_selector": "tr.pr-list-page-row",
+        "title_selector": "td.views-field-title a",
+        "url_selector": "td.views-field-title a",
+        "summary_selector": "td.views-field-field-description",
+        "date_selector": "td.views-field-field-publish-date time",
+        "limit": 10
+      },
+      "position": { "x": 280, "y": 120 },
+      "label": "Scrape: SEC Press Releases"
+    },
+    {
+      "id": "filter-keywords",
+      "node_type": "filter",
+      "kind": "keyword",
+      "config": {
+        "keywords": ["bitcoin", "btc", "crypto", "cryptocurrency", "digital asset", "stablecoin", "cbdc", "sec", "etf", "defi", "ethereum", "eth", "blockchain"],
+        "require_all": false,
+        "field": "title_or_summary"
+      },
+      "position": { "x": 560, "y": 0 },
+      "label": "Keyword Filter"
+    },
+    {
+      "id": "executor-claude",
+      "node_type": "executor",
+      "kind": "claude-api",
+      "config": {
+        "prompt": "prompts/crypto_news_brief.md",
+        "permissions": []
+      },
+      "position": { "x": 840, "y": 0 },
+      "label": "Claude: crypto_news_brief.md"
+    },
+    {
+      "id": "sink-notion",
+      "node_type": "sink",
+      "kind": "notion",
+      "config": {
+        "token_env": "NOTION_TOKEN",
+        "database_id": "YOUR_DATABASE_ID_HERE"
+      },
+      "position": { "x": 1120, "y": 0 },
+      "label": "Notion: Review Queue"
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "trigger-cron", "target": "source-google-news-btc" },
+    { "id": "e2", "source": "trigger-cron", "target": "source-google-news-reg" },
+    { "id": "e3", "source": "trigger-cron", "target": "source-sec-press" },
+    { "id": "e4", "source": "source-google-news-btc", "target": "filter-keywords" },
+    { "id": "e5", "source": "source-google-news-reg", "target": "filter-keywords" },
+    { "id": "e6", "source": "source-sec-press", "target": "filter-keywords" },
+    { "id": "e7", "source": "filter-keywords", "target": "executor-claude" },
+    { "id": "e8", "source": "executor-claude", "target": "sink-notion" }
+  ],
+  "created_at": "2025-01-01T00:00:00Z",
+  "updated_at": "2025-01-01T00:00:00Z"
+}

--- a/prompts/crypto_breaking_news.md
+++ b/prompts/crypto_breaking_news.md
@@ -1,0 +1,48 @@
+You are a crypto news researcher compiling a comprehensive report from monitored sources. Your job is to analyze the provided content, identify the most significant stories, and produce a structured Notion report.
+
+## Output Format
+
+Produce the following report in Markdown:
+
+---
+
+## Crypto News Report — {{timestamp}}
+
+### Sources Checked ({{item_count}} items)
+
+List every source scanned with a one-line status (e.g., "CoinTelegraph RSS — 10 items, 2 relevant" or "Japan FSA page — no relevant updates").
+
+### Key Findings
+
+For each significant finding (up to 5):
+- **Headline**: Clear, factual title
+- **Source**: Publication name + link
+- **Summary**: 2-3 sentences of context and significance
+- **Evidence**: Direct quotes or data points from the source
+- **Relevance**: Why this matters for the crypto market
+
+### Recommended Posts
+
+For each recommended post (1-3):
+- **Post copy**: Draft X/Twitter post, under 270 characters, neutral tone, 2-3 relevant emojis, must include source link
+- **Character count**: Exact count
+- **Source**: Link to original article
+
+### Discarded Items
+
+For each item reviewed but not selected:
+- **Title** + source
+- **Reason**: Brief explanation why it was not selected (e.g., "not Asia-specific", "stale news > 24h old", "opinion piece")
+
+---
+
+## Style Rules
+
+- Neutral, factual tone — no opinions, predictions, or speculation
+- Each recommended post must be under 270 characters including the source link
+- Use 2-3 emojis per post that are relevant to the content
+- Every post must include a source link
+- Prioritize: regulatory actions, major exchange news, significant price movements, institutional adoption
+- Focus on Asia-Pacific region relevance
+
+{{content}}

--- a/prompts/crypto_news_brief.md
+++ b/prompts/crypto_news_brief.md
@@ -1,0 +1,44 @@
+# Crypto News Brief
+
+You are a neutral news correspondent covering cryptocurrency, Bitcoin, and digital asset regulation. Your job is to draft short posts for X/Twitter based on the news feed below.
+
+## Voice & Tone
+
+- **Neutral and factual.** No opinions, no predictions, no speculation.
+- Report what happened, who said it, and why it matters.
+- Write like a wire service (AP, Reuters), not a crypto influencer.
+- No hype words: "bullish", "bearish", "moon", "generational", "few understand this".
+- No hedging: "potentially", "arguably", "it remains to be seen".
+
+## Format Rules
+
+- Each post must be **under 270 characters** (leave room for link).
+- Include 2-3 relevant emojis max per post.
+- Always include the source link at the end.
+- One fact per post. Don't cram multiple stories into one post.
+- Lead with the news, not with filler ("Breaking:", "Just in:" are OK sparingly).
+
+## NEVER do these
+
+- Give financial advice or price predictions
+- Use em dashes
+- Start with "In a significant development" or any throat-clearing
+- Use exclamation points
+- Editorialize ("this is huge", "game changer", "this changes everything")
+- Use crypto slang ("WAGMI", "NGMI", "ser", "wen")
+
+## Output Format
+
+For each newsworthy item, produce a post. Number them. Skip items that are not crypto/Bitcoin/digital-asset related. Skip duplicates covering the same story.
+
+## Posts
+
+[Numbered list of drafted posts, each under 270 characters with source link]
+
+## News Feed ({{item_count}} items, fetched {{timestamp}})
+
+{{content}}
+
+---
+
+Draft the posts now. Factual, concise, under 270 characters each. Include source links.

--- a/src/flows/mod.rs
+++ b/src/flows/mod.rs
@@ -39,6 +39,7 @@ pub struct Node {
 pub enum NodeType {
     Trigger,
     Source,
+    Filter,
     Executor,
     Sink,
 }
@@ -96,6 +97,10 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&NodeType::Source).unwrap(),
             "\"source\""
+        );
+        assert_eq!(
+            serde_json::to_string(&NodeType::Filter).unwrap(),
+            "\"filter\""
         );
         assert_eq!(
             serde_json::to_string(&NodeType::Executor).unwrap(),

--- a/src/flows/runner.rs
+++ b/src/flows/runner.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result, bail};
 use chrono::Utc;
+use tracing::Instrument;
 use uuid::Uuid;
 
 use crate::config::{SinkConfig, SourceConfig};
@@ -13,6 +14,8 @@ use crate::github::client::GithubClient;
 use crate::tasks::context::render_prompt;
 use crate::tasks::executors::claude_code::ClaudeCodeExecutor;
 use crate::tasks::executors::Executor;
+use crate::tasks::filters::Filter;
+use crate::tasks::filters::keyword::{KeywordFilter, MatchField};
 use crate::tasks::sources::{self, ContentItem};
 use crate::tasks::triggers::cron::{format_items, resolve_sinks};
 
@@ -24,6 +27,7 @@ pub struct FlowRunner {
 impl FlowRunner {
     pub async fn execute(&self, flow: &Flow, history: &RunHistory) -> Result<FlowRun> {
         let run_id = Uuid::new_v4().to_string();
+        let short_id = &run_id[..8];
         let mut run = FlowRun {
             id: run_id.clone(),
             flow_id: flow.id.clone(),
@@ -35,7 +39,13 @@ impl FlowRunner {
         };
         history.add_run(run.clone()).await;
 
-        let result = self.execute_inner(flow, &run_id, history).await;
+        let span = tracing::info_span!("flow_run", flow = %flow.name, run = %short_id);
+
+        tracing::info!(parent: &span, nodes = flow.nodes.len(), edges = flow.edges.len(), "▶ Started");
+
+        let start = std::time::Instant::now();
+        let result = self.execute_inner(flow, &run_id, history).instrument(span.clone()).await;
+        let elapsed = start.elapsed();
 
         match &result {
             Ok(_) => {
@@ -45,6 +55,7 @@ impl FlowRunner {
                         r.finished_at = Some(Utc::now());
                     })
                     .await;
+                tracing::info!(parent: &span, elapsed = format_args!("{:.1}s", elapsed.as_secs_f64()), "✓ Completed");
             }
             Err(e) => {
                 let err_msg = format!("{e:#}");
@@ -52,9 +63,10 @@ impl FlowRunner {
                     .update_run(&flow.id, &run_id, |r| {
                         r.status = RunStatus::Failed;
                         r.finished_at = Some(Utc::now());
-                        r.error = Some(err_msg);
+                        r.error = Some(err_msg.clone());
                     })
                     .await;
+                tracing::error!(parent: &span, elapsed = format_args!("{:.1}s", elapsed.as_secs_f64()), error = %err_msg, "✗ Failed");
             }
         }
 
@@ -88,13 +100,27 @@ impl FlowRunner {
             .filter(|n| n.node_type == NodeType::Source)
             .collect();
 
+        let filter_nodes: Vec<_> = flow
+            .nodes
+            .iter()
+            .filter(|n| n.node_type == NodeType::Filter)
+            .collect();
+
         let sink_nodes: Vec<_> = flow
             .nodes
             .iter()
             .filter(|n| n.node_type == NodeType::Sink)
             .collect();
 
-        // 1. Fetch sources concurrently
+        tracing::info!(
+            "Pipeline: {} source(s) → {} filter(s) → {} → {} sink(s)",
+            source_nodes.len(),
+            filter_nodes.len(),
+            executor_node.kind,
+            sink_nodes.len(),
+        );
+
+        // ── 1. SOURCES ──────────────────────────────────────────────
         let source_configs = parse_source_configs(&source_nodes)?;
         let github_token = self
             .github_client
@@ -103,7 +129,7 @@ impl FlowRunner {
             .flatten();
 
         let items: Vec<ContentItem> = if !source_configs.is_empty() {
-            // Record source node runs
+            // Record node runs for tracking
             for node in &source_nodes {
                 let node_run = NodeRun {
                     node_id: node.id.clone(),
@@ -117,18 +143,42 @@ impl FlowRunner {
                     .await;
             }
 
+            let fetch_start = std::time::Instant::now();
             let result =
                 sources::fetch_all(&source_configs, &self.http_client, github_token.as_deref())
                     .await;
+            let fetch_elapsed = fetch_start.elapsed();
+
+            tracing::info!(
+                items = result.len(),
+                elapsed = format_args!("{:.1}s", fetch_elapsed.as_secs_f64()),
+                "✓ Sources fetched",
+            );
+
+            // Log a sample of item titles at debug
+            for (i, item) in result.iter().take(5).enumerate() {
+                tracing::debug!(
+                    "[{}/{}] {} ({})",
+                    i + 1,
+                    result.len(),
+                    truncate(&item.title, 80),
+                    truncate(&item.url, 60),
+                );
+            }
+            if result.len() > 5 {
+                tracing::debug!("... and {} more items", result.len() - 5);
+            }
 
             // Mark source nodes as complete
             for node in &source_nodes {
                 let nid = node.id.clone();
+                let preview = format!("{} items fetched", result.len());
                 history
                     .update_run(&flow.id, run_id, |r| {
                         if let Some(nr) = r.node_runs.iter_mut().find(|nr| nr.node_id == nid) {
                             nr.status = RunStatus::Success;
                             nr.finished_at = Some(Utc::now());
+                            nr.output_preview = Some(preview);
                         }
                     })
                     .await;
@@ -136,10 +186,52 @@ impl FlowRunner {
 
             result
         } else {
+            tracing::info!("No sources configured, skipping fetch");
             vec![]
         };
 
-        // 2. Build template variables
+        // ── 2. FILTERS ──────────────────────────────────────────────
+        let mut items = items;
+        for node in &filter_nodes {
+            let before_count = items.len();
+
+            let filter_run = NodeRun {
+                node_id: node.id.clone(),
+                status: RunStatus::Running,
+                started_at: Utc::now(),
+                finished_at: None,
+                output_preview: None,
+            };
+            history
+                .update_run(&flow.id, run_id, |r| r.node_runs.push(filter_run))
+                .await;
+
+            let filter = parse_filter_config(node)?;
+            items = filter.apply(items);
+
+            let dropped = before_count - items.len();
+            tracing::info!(
+                filter = %node.label,
+                "{} → {} items ({} dropped)",
+                before_count,
+                items.len(),
+                dropped,
+            );
+
+            let nid = node.id.clone();
+            let preview = format!("{} → {} items ({} dropped)", before_count, items.len(), dropped);
+            history
+                .update_run(&flow.id, run_id, |r| {
+                    if let Some(nr) = r.node_runs.iter_mut().find(|nr| nr.node_id == nid) {
+                        nr.status = RunStatus::Success;
+                        nr.finished_at = Some(Utc::now());
+                        nr.output_preview = Some(preview);
+                    }
+                })
+                .await;
+        }
+
+        // ── 3. PROMPT RENDERING ─────────────────────────────────────
         let content = format_items(&items);
         let timestamp = Utc::now().format("%Y-%m-%d %H:%M UTC").to_string();
 
@@ -148,29 +240,38 @@ impl FlowRunner {
         vars.insert("item_count".to_string(), items.len().to_string());
         vars.insert("timestamp".to_string(), timestamp);
 
-        // 3. Read and render prompt template
         let prompt_path = executor_node.config["prompt"]
             .as_str()
             .context("executor node missing 'prompt' config")?;
 
-        let prompt_template = std::fs::read_to_string(prompt_path)
-            .with_context(|| format!("failed to read prompt file: {prompt_path}"))?;
+        let prompt_template = if prompt_path.ends_with(".md") || prompt_path.ends_with(".txt") || std::path::Path::new(prompt_path).exists() {
+            tracing::info!(path = %prompt_path, "Loading prompt from file");
+            std::fs::read_to_string(prompt_path)
+                .with_context(|| format!("failed to read prompt file: {prompt_path}"))?
+        } else {
+            tracing::info!(len = prompt_path.len(), "Using inline prompt");
+            prompt_path.to_string()
+        };
 
         // Fetch market data if needed
         if prompt_template.contains("{{market_data}}") {
+            tracing::info!("Fetching market data");
             let market_data = match tokio::time::timeout(
                 std::time::Duration::from_secs(15),
                 crate::tasks::sources::market::fetch_market_snapshot(&self.http_client),
             )
             .await
             {
-                Ok(Ok(data)) => data,
+                Ok(Ok(data)) => {
+                    tracing::info!(len = data.len(), "✓ Market data fetched");
+                    data
+                }
                 Ok(Err(e)) => {
-                    tracing::warn!(error = %e, "Failed to fetch market data");
+                    tracing::warn!(error = %e, "⚠ Market data fetch failed, using fallback");
                     "Market data unavailable.".to_string()
                 }
                 Err(_) => {
-                    tracing::warn!("Market data fetch timed out");
+                    tracing::warn!("⚠ Market data fetch timed out, using fallback");
                     "Market data unavailable.".to_string()
                 }
             };
@@ -179,7 +280,21 @@ impl FlowRunner {
 
         let rendered = render_prompt(&prompt_template, &vars);
 
-        // 4. Execute
+        // If the prompt didn't contain {{content}} but we have source data, append it
+        let rendered = if !items.is_empty() && !prompt_template.contains("{{content}}") {
+            tracing::debug!("Prompt has no {{content}} placeholder, appending source data");
+            format!("{rendered}\n\n<<<\n{}\n>>>", vars.get("content").cloned().unwrap_or_default())
+        } else {
+            rendered
+        };
+
+        tracing::info!(
+            chars = rendered.len(),
+            items = items.len(),
+            "✓ Prompt rendered",
+        );
+
+        // ── 4. EXECUTOR ─────────────────────────────────────────────
         let permissions: Vec<String> = executor_node.config["permissions"]
             .as_array()
             .map(|arr| {
@@ -194,7 +309,20 @@ impl FlowRunner {
             .map(PathBuf::from)
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
 
-        let executor = ClaudeCodeExecutor::new(permissions);
+        let append_system_prompt = executor_node.config["append_system_prompt"]
+            .as_str()
+            .map(String::from);
+
+        let has_system_prompt = append_system_prompt.is_some();
+        let executor = ClaudeCodeExecutor::new(permissions.clone(), append_system_prompt);
+
+        let perms_display = if permissions.is_empty() { "ALL".to_string() } else { permissions.join(", ") };
+        tracing::info!(
+            executor = %executor_node.kind,
+            permissions = %perms_display,
+            system_prompt = has_system_prompt,
+            "⟶ Executing",
+        );
 
         let exec_node_run = NodeRun {
             node_id: executor_node.id.clone(),
@@ -207,10 +335,20 @@ impl FlowRunner {
             .update_run(&flow.id, run_id, |r| r.node_runs.push(exec_node_run))
             .await;
 
+        let exec_start = std::time::Instant::now();
         let exec_result = executor
             .execute(&rendered, &working_dir)
             .await
             .context("executor failed")?;
+        let exec_elapsed = exec_start.elapsed();
+
+        tracing::info!(
+            turns = exec_result.num_turns,
+            cost = format_args!("${:.4}", exec_result.cost_usd),
+            output_chars = exec_result.text.len(),
+            elapsed = format_args!("{:.1}s", exec_elapsed.as_secs_f64()),
+            "✓ Executor finished",
+        );
 
         let preview = if exec_result.text.len() > 500 {
             format!("{}...", &exec_result.text[..500])
@@ -229,13 +367,14 @@ impl FlowRunner {
             })
             .await;
 
-        // 5. Deliver to sinks
+        // ── 5. SINKS ────────────────────────────────────────────────
         if !exec_result.text.is_empty() {
             let sink_configs = parse_sink_configs(&sink_nodes)?;
             let resolved_sinks = resolve_sinks(&sink_configs, &self.http_client)?;
 
             for (i, sink) in resolved_sinks.iter().enumerate() {
                 let sink_node = &sink_nodes[i];
+
                 let sink_run = NodeRun {
                     node_id: sink_node.id.clone(),
                     status: RunStatus::Running,
@@ -247,29 +386,57 @@ impl FlowRunner {
                     .update_run(&flow.id, run_id, |r| r.node_runs.push(sink_run))
                     .await;
 
+                let sink_start = std::time::Instant::now();
                 let result = sink.deliver(&exec_result.text).await;
+                let sink_elapsed = sink_start.elapsed();
+
                 let nid = sink_node.id.clone();
-                let status = if result.is_ok() {
-                    RunStatus::Success
-                } else {
-                    RunStatus::Failed
+                let (status, preview) = match &result {
+                    Ok(_) => {
+                        tracing::info!(
+                            sink = %sink_node.label,
+                            elapsed = format_args!("{:.1}s", sink_elapsed.as_secs_f64()),
+                            "✓ Delivered",
+                        );
+                        (RunStatus::Success, format!("Delivered in {:.1}s", sink_elapsed.as_secs_f64()))
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            sink = %sink_node.label,
+                            error = %e,
+                            "✗ Delivery failed",
+                        );
+                        (RunStatus::Failed, format!("Failed: {e}"))
+                    }
                 };
+
                 history
                     .update_run(&flow.id, run_id, |r| {
                         if let Some(nr) = r.node_runs.iter_mut().find(|nr| nr.node_id == nid) {
                             nr.status = status;
                             nr.finished_at = Some(Utc::now());
+                            nr.output_preview = Some(preview);
                         }
                     })
                     .await;
-
-                if let Err(e) = result {
-                    tracing::error!(error = %e, "Failed to deliver to sink");
-                }
             }
+        } else {
+            tracing::warn!("⚠ Executor returned empty output, skipping sinks");
         }
 
         Ok(())
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        let mut end = max;
+        while !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &s[..end])
     }
 }
 
@@ -285,7 +452,22 @@ fn parse_source_configs(
                     .context("rss node missing 'url'")?
                     .to_string();
                 let limit = node.config["limit"].as_u64().unwrap_or(10) as usize;
-                SourceConfig::Rss { url, limit }
+                let keywords = node.config["keywords"]
+                    .as_array()
+                    .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+                    .unwrap_or_default();
+                SourceConfig::Rss { url, limit, keywords }
+            }
+            "web-scrape" => {
+                let url = node.config["url"]
+                    .as_str()
+                    .context("web-scrape node missing 'url'")?
+                    .to_string();
+                let keywords = node.config["keywords"]
+                    .as_array()
+                    .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+                    .unwrap_or_default();
+                SourceConfig::WebScrape { url, keywords }
             }
             "github-merged-prs" => {
                 let repos = node.config["repos"]
@@ -297,6 +479,28 @@ fn parse_source_configs(
                 let since_days = node.config["since_days"].as_u64().unwrap_or(7);
                 SourceConfig::GithubMergedPrs { repos, since_days }
             }
+            "web-scraper" => {
+                let url = node.config["url"]
+                    .as_str()
+                    .context("web-scraper node missing 'url'")?
+                    .to_string();
+                let base_url = node.config["base_url"].as_str().map(String::from);
+                let items_selector = node.config["items_selector"]
+                    .as_str()
+                    .context("web-scraper node missing 'items_selector'")?
+                    .to_string();
+                let title_selector = node.config["title_selector"].as_str().map(String::from);
+                let url_selector = node.config["url_selector"].as_str().map(String::from);
+                let summary_selector = node.config["summary_selector"].as_str().map(String::from);
+                let date_selector = node.config["date_selector"].as_str().map(String::from);
+                let date_format = node.config["date_format"].as_str().map(String::from);
+                let limit = node.config["limit"].as_u64().unwrap_or(10) as usize;
+                SourceConfig::WebScraper {
+                    url, base_url, items_selector, title_selector,
+                    url_selector, summary_selector, date_selector,
+                    date_format, limit,
+                }
+            }
             "market-data" => {
                 // Market data is handled specially via template variable
                 continue;
@@ -306,6 +510,27 @@ fn parse_source_configs(
         configs.push(config);
     }
     Ok(configs)
+}
+
+fn parse_filter_config(node: &crate::flows::Node) -> Result<Box<dyn Filter>> {
+    match node.kind.as_str() {
+        "keyword" => {
+            let keywords: Vec<String> = node.config["keywords"]
+                .as_array()
+                .context("keyword filter missing 'keywords'")?
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+            let require_all = node.config["require_all"].as_bool().unwrap_or(false);
+            let field = match node.config["field"].as_str().unwrap_or("title_or_summary") {
+                "title" => MatchField::Title,
+                "summary" => MatchField::Summary,
+                _ => MatchField::TitleOrSummary,
+            };
+            Ok(Box::new(KeywordFilter::new(keywords, require_all, field)))
+        }
+        other => bail!("unknown filter kind: {other}"),
+    }
 }
 
 fn parse_sink_configs(nodes: &[&crate::flows::Node]) -> Result<Vec<SinkConfig>> {

--- a/src/server/flow_routes.rs
+++ b/src/server/flow_routes.rs
@@ -261,7 +261,17 @@ async fn get_node_types() -> Json<Value> {
                 "label": "RSS Feed",
                 "config_schema": {
                     "url": { "type": "string", "description": "Feed URL", "required": true },
-                    "limit": { "type": "number", "description": "Max items to fetch", "default": 10 }
+                    "limit": { "type": "number", "description": "Max items to fetch", "default": 10 },
+                    "keywords": { "type": "array", "description": "Filter items by keywords (case-insensitive, any match)", "default": [] }
+                }
+            },
+            {
+                "kind": "web-scrape",
+                "node_type": "source",
+                "label": "Web Scrape",
+                "config_schema": {
+                    "url": { "type": "string", "description": "Page URL to scrape", "required": true },
+                    "keywords": { "type": "array", "description": "Filter by keywords (case-insensitive, any match)", "default": [] }
                 }
             },
             {
@@ -274,10 +284,36 @@ async fn get_node_types() -> Json<Value> {
                 }
             },
             {
+                "kind": "web-scraper",
+                "node_type": "source",
+                "label": "Web Scraper (CSS)",
+                "config_schema": {
+                    "url": { "type": "string", "description": "Page URL to scrape", "required": true },
+                    "base_url": { "type": "string", "description": "Base URL for resolving relative links" },
+                    "items_selector": { "type": "string", "description": "CSS selector for item containers", "required": true },
+                    "title_selector": { "type": "string", "description": "CSS selector for title within item" },
+                    "url_selector": { "type": "string", "description": "CSS selector for link within item" },
+                    "summary_selector": { "type": "string", "description": "CSS selector for summary within item" },
+                    "date_selector": { "type": "string", "description": "CSS selector for date within item" },
+                    "date_format": { "type": "string", "description": "Date format string (e.g. %Y-%m-%d)" },
+                    "limit": { "type": "number", "description": "Max items to extract", "default": 10 }
+                }
+            },
+            {
                 "kind": "market-data",
                 "node_type": "source",
                 "label": "Market Data",
                 "config_schema": {}
+            },
+            {
+                "kind": "keyword",
+                "node_type": "filter",
+                "label": "Keyword Filter",
+                "config_schema": {
+                    "keywords": { "type": "array", "description": "Keywords to match (case-insensitive)", "required": true },
+                    "require_all": { "type": "boolean", "description": "Require all keywords to match", "default": false },
+                    "field": { "type": "string", "description": "Field to match: title, summary, or title_or_summary", "default": "title_or_summary" }
+                }
             },
             {
                 "kind": "claude-code",
@@ -285,7 +321,8 @@ async fn get_node_types() -> Json<Value> {
                 "label": "Claude Code",
                 "config_schema": {
                     "prompt": { "type": "string", "description": "Prompt file path or inline prompt", "required": true },
-                    "permissions": { "type": "array", "description": "Tool permissions (e.g. Bash, Read)", "default": [] }
+                    "permissions": { "type": "array", "description": "Tool permissions (e.g. Bash, Read)", "default": [] },
+                    "append_system_prompt": { "type": "string", "description": "Additional system prompt appended to Claude's instructions" }
                 }
             },
             {

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -283,7 +283,7 @@ async fn trigger_review(
         let rendered = crate::tasks::context::render_prompt(&prompt_template, &context);
 
         let executor =
-            crate::tasks::executors::claude_code::ClaudeCodeExecutor::new(permissions);
+            crate::tasks::executors::claude_code::ClaudeCodeExecutor::new(permissions, None);
 
         {
             let mut active = task_state.active_reviews.lock().await;
@@ -369,6 +369,7 @@ async fn trigger_task(
 
     let executor = crate::tasks::executors::claude_code::ClaudeCodeExecutor::new(
         task.permissions.clone(),
+        None,
     );
 
     let github_token = state.config.github_token();

--- a/src/tasks/filters/keyword.rs
+++ b/src/tasks/filters/keyword.rs
@@ -1,0 +1,171 @@
+use super::Filter;
+use crate::tasks::sources::ContentItem;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchField {
+    Title,
+    Summary,
+    TitleOrSummary,
+}
+
+pub struct KeywordFilter {
+    keywords: Vec<String>,
+    require_all: bool,
+    field: MatchField,
+}
+
+impl KeywordFilter {
+    pub fn new(keywords: Vec<String>, require_all: bool, field: MatchField) -> Self {
+        Self {
+            keywords: keywords.into_iter().map(|k| k.to_lowercase()).collect(),
+            require_all,
+            field,
+        }
+    }
+
+    fn matches_text(&self, text: &str) -> bool {
+        let lower = text.to_lowercase();
+        if self.require_all {
+            self.keywords.iter().all(|kw| lower.contains(kw.as_str()))
+        } else {
+            self.keywords.iter().any(|kw| lower.contains(kw.as_str()))
+        }
+    }
+}
+
+impl Filter for KeywordFilter {
+    fn apply(&self, items: Vec<ContentItem>) -> Vec<ContentItem> {
+        items
+            .into_iter()
+            .filter(|item| match self.field {
+                MatchField::Title => self.matches_text(&item.title),
+                MatchField::Summary => self.matches_text(&item.summary),
+                MatchField::TitleOrSummary => {
+                    self.matches_text(&item.title) || self.matches_text(&item.summary)
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_item(title: &str, summary: &str) -> ContentItem {
+        ContentItem {
+            title: title.to_string(),
+            url: String::new(),
+            summary: summary.to_string(),
+            published: None,
+            image_url: None,
+        }
+    }
+
+    #[test]
+    fn test_keyword_filter_any_title() {
+        let filter = KeywordFilter::new(
+            vec!["bitcoin".into(), "ethereum".into()],
+            false,
+            MatchField::Title,
+        );
+        let items = vec![
+            make_item("Bitcoin hits new high", "Price surges"),
+            make_item("Apple releases new phone", "Tech news"),
+            make_item("Ethereum upgrade live", "Network update"),
+        ];
+        let result = filter.apply(items);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].title, "Bitcoin hits new high");
+        assert_eq!(result[1].title, "Ethereum upgrade live");
+    }
+
+    #[test]
+    fn test_keyword_filter_require_all() {
+        let filter = KeywordFilter::new(
+            vec!["bitcoin".into(), "etf".into()],
+            true,
+            MatchField::Title,
+        );
+        let items = vec![
+            make_item("Bitcoin ETF approved", ""),
+            make_item("Bitcoin hits high", ""),
+            make_item("New ETF launched", ""),
+        ];
+        let result = filter.apply(items);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].title, "Bitcoin ETF approved");
+    }
+
+    #[test]
+    fn test_keyword_filter_case_insensitive() {
+        let filter = KeywordFilter::new(
+            vec!["BTC".into()],
+            false,
+            MatchField::Title,
+        );
+        let items = vec![
+            make_item("btc price update", ""),
+            make_item("BTC Soars", ""),
+        ];
+        let result = filter.apply(items);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_keyword_filter_summary_field() {
+        let filter = KeywordFilter::new(
+            vec!["crypto".into()],
+            false,
+            MatchField::Summary,
+        );
+        let items = vec![
+            make_item("Market update", "Crypto markets rally"),
+            make_item("Market update", "Stock markets rally"),
+        ];
+        let result = filter.apply(items);
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_keyword_filter_title_or_summary() {
+        let filter = KeywordFilter::new(
+            vec!["sec".into()],
+            false,
+            MatchField::TitleOrSummary,
+        );
+        let items = vec![
+            make_item("SEC ruling", "Details here"),
+            make_item("Market news", "The SEC issued guidance"),
+            make_item("Weather forecast", "Sunny skies"),
+        ];
+        let result = filter.apply(items);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_keyword_filter_empty_keywords() {
+        let filter = KeywordFilter::new(
+            vec![],
+            false,
+            MatchField::Title,
+        );
+        let items = vec![make_item("Anything", "")];
+        // With empty keywords and require_all=false, any() returns false
+        let result = filter.apply(items);
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_keyword_filter_empty_keywords_require_all() {
+        let filter = KeywordFilter::new(
+            vec![],
+            true,
+            MatchField::Title,
+        );
+        let items = vec![make_item("Anything", "")];
+        // With empty keywords and require_all=true, all() returns true
+        let result = filter.apply(items);
+        assert_eq!(result.len(), 1);
+    }
+}

--- a/src/tasks/filters/mod.rs
+++ b/src/tasks/filters/mod.rs
@@ -1,0 +1,7 @@
+pub mod keyword;
+
+use crate::tasks::sources::ContentItem;
+
+pub trait Filter: Send + Sync {
+    fn apply(&self, items: Vec<ContentItem>) -> Vec<ContentItem>;
+}

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,6 +1,7 @@
 pub mod context;
 pub mod diff;
 pub mod executors;
+pub mod filters;
 pub mod sinks;
 pub mod sources;
 pub mod triggers;
@@ -43,7 +44,7 @@ fn load_prompt_and_executor(task: &TaskConfig) -> Option<(String, Box<dyn Execut
     };
 
     let executor: Box<dyn Executor> = match task.executor {
-        ExecutorType::ClaudeCode => Box::new(ClaudeCodeExecutor::new(task.permissions.clone())),
+        ExecutorType::ClaudeCode => Box::new(ClaudeCodeExecutor::new(task.permissions.clone(), task.append_system_prompt.clone())),
         ExecutorType::ClaudeApi => {
             tracing::error!(task = %task.name, "claude-api executor not yet implemented");
             return None;

--- a/src/tasks/sources/mod.rs
+++ b/src/tasks/sources/mod.rs
@@ -1,6 +1,7 @@
 pub mod market;
 pub mod github_prs;
 pub mod rss;
+pub mod web_scrape;
 
 use chrono::{DateTime, Utc};
 use futures::future::join_all;
@@ -16,6 +17,14 @@ pub struct ContentItem {
     pub image_url: Option<String>,
 }
 
+fn keyword_matches(item: &ContentItem, keywords: &[String]) -> bool {
+    if keywords.is_empty() {
+        return true;
+    }
+    let haystack = format!("{} {}", item.title, item.summary).to_lowercase();
+    keywords.iter().any(|kw| haystack.contains(&kw.to_lowercase()))
+}
+
 pub async fn fetch_all(
     sources: &[SourceConfig],
     http_client: &reqwest::Client,
@@ -25,14 +34,34 @@ pub async fn fetch_all(
         .iter()
         .map(|source| async move {
             match source {
-                SourceConfig::Rss { url, limit } => {
+                SourceConfig::Rss { url, limit, keywords } => {
                     match rss::fetch_feed(http_client, url, *limit).await {
                         Ok(feed_items) => {
-                            tracing::info!(url = %url, count = feed_items.len(), "Fetched RSS feed");
-                            feed_items
+                            let filtered: Vec<_> = feed_items
+                                .into_iter()
+                                .filter(|item| keyword_matches(item, keywords))
+                                .collect();
+                            tracing::debug!(url = %url, count = filtered.len(), "Fetched RSS feed");
+                            filtered
                         }
                         Err(e) => {
-                            tracing::error!(url = %url, error = %e, "Failed to fetch RSS feed");
+                            tracing::warn!(url = %url, error = %e, "Failed to fetch RSS feed");
+                            Vec::new()
+                        }
+                    }
+                }
+                SourceConfig::WebScrape { url, keywords } => {
+                    match web_scrape::fetch_page_text(http_client, url).await {
+                        Ok(items) => {
+                            let filtered: Vec<_> = items
+                                .into_iter()
+                                .filter(|item| keyword_matches(item, keywords))
+                                .collect();
+                            tracing::debug!(url = %url, count = filtered.len(), "Fetched web page");
+                            filtered
+                        }
+                        Err(e) => {
+                            tracing::warn!(url = %url, error = %e, "Failed to fetch web page");
                             Vec::new()
                         }
                     }
@@ -44,11 +73,32 @@ pub async fn fetch_all(
                     };
                     match github_prs::fetch_merged_prs(http_client, token, repos, *since_days).await {
                         Ok(items) => {
-                            tracing::info!(repos = ?repos, count = items.len(), "Fetched merged PRs");
+                            tracing::debug!(repos = ?repos, count = items.len(), "Fetched merged PRs");
                             items
                         }
                         Err(e) => {
                             tracing::error!(repos = ?repos, error = %e, "Failed to fetch merged PRs");
+                            Vec::new()
+                        }
+                    }
+                }
+                SourceConfig::WebScraper {
+                    url, base_url, items_selector, title_selector,
+                    url_selector, summary_selector, date_selector,
+                    date_format, limit,
+                } => {
+                    match web_scrape::fetch_page(
+                        http_client, url, items_selector,
+                        title_selector.as_deref(), url_selector.as_deref(),
+                        summary_selector.as_deref(), date_selector.as_deref(),
+                        date_format.as_deref(), *limit, base_url.as_deref(),
+                    ).await {
+                        Ok(items) => {
+                            tracing::debug!(url = %url, count = items.len(), "Fetched web scrape");
+                            items
+                        }
+                        Err(e) => {
+                            tracing::error!(url = %url, error = %e, "Failed to scrape page");
                             Vec::new()
                         }
                     }
@@ -58,4 +108,57 @@ pub async fn fetch_all(
         .collect();
 
     join_all(futures).await.into_iter().flatten().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_item(title: &str, summary: &str) -> ContentItem {
+        ContentItem {
+            title: title.to_string(),
+            url: String::new(),
+            summary: summary.to_string(),
+            published: None,
+            image_url: None,
+        }
+    }
+
+    #[test]
+    fn test_keyword_matches_empty_keywords() {
+        let item = make_item("anything", "goes");
+        assert!(keyword_matches(&item, &[]));
+    }
+
+    #[test]
+    fn test_keyword_matches_title() {
+        let item = make_item("Bitcoin surges to new high", "market update");
+        assert!(keyword_matches(&item, &["bitcoin".to_string()]));
+    }
+
+    #[test]
+    fn test_keyword_matches_summary() {
+        let item = make_item("Market Update", "ethereum hits resistance level");
+        assert!(keyword_matches(&item, &["ethereum".to_string()]));
+    }
+
+    #[test]
+    fn test_keyword_matches_case_insensitive() {
+        let item = make_item("BITCOIN news", "");
+        assert!(keyword_matches(&item, &["bitcoin".to_string()]));
+        assert!(keyword_matches(&item, &["Bitcoin".to_string()]));
+        assert!(keyword_matches(&item, &["BITCOIN".to_string()]));
+    }
+
+    #[test]
+    fn test_keyword_no_match() {
+        let item = make_item("Stock market update", "S&P 500 rallies");
+        assert!(!keyword_matches(&item, &["bitcoin".to_string(), "crypto".to_string()]));
+    }
+
+    #[test]
+    fn test_keyword_any_match() {
+        let item = make_item("Crypto regulation", "new laws proposed");
+        assert!(keyword_matches(&item, &["bitcoin".to_string(), "crypto".to_string()]));
+    }
 }

--- a/src/tasks/sources/web_scrape.rs
+++ b/src/tasks/sources/web_scrape.rs
@@ -1,0 +1,417 @@
+use anyhow::{Context, Result};
+use scraper::{Html, Selector};
+
+use super::ContentItem;
+
+pub async fn fetch_page(
+    client: &reqwest::Client,
+    url: &str,
+    items_selector: &str,
+    title_selector: Option<&str>,
+    url_selector: Option<&str>,
+    summary_selector: Option<&str>,
+    date_selector: Option<&str>,
+    date_format: Option<&str>,
+    limit: usize,
+    base_url: Option<&str>,
+) -> Result<Vec<ContentItem>> {
+    let html = client
+        .get(url)
+        .timeout(std::time::Duration::from_secs(30))
+        .send()
+        .await
+        .context("failed to fetch page")?
+        .error_for_status()
+        .with_context(|| format!("page returned error status: {url}"))?
+        .text()
+        .await
+        .context("failed to read page body")?;
+
+    parse_page(&html, items_selector, title_selector, url_selector, summary_selector, date_selector, date_format, limit, base_url)
+}
+
+fn parse_page(
+    html: &str,
+    items_selector: &str,
+    title_selector: Option<&str>,
+    url_selector: Option<&str>,
+    summary_selector: Option<&str>,
+    date_selector: Option<&str>,
+    date_format: Option<&str>,
+    limit: usize,
+    base_url: Option<&str>,
+) -> Result<Vec<ContentItem>> {
+    let document = Html::parse_document(html);
+    let items_sel = Selector::parse(items_selector)
+        .map_err(|e| anyhow::anyhow!("invalid items selector '{}': {:?}", items_selector, e))?;
+
+    let title_sel = title_selector
+        .map(|s| Selector::parse(s).map_err(|e| anyhow::anyhow!("invalid title selector: {:?}", e)))
+        .transpose()?;
+    let url_sel = url_selector
+        .map(|s| Selector::parse(s).map_err(|e| anyhow::anyhow!("invalid url selector: {:?}", e)))
+        .transpose()?;
+    let summary_sel = summary_selector
+        .map(|s| Selector::parse(s).map_err(|e| anyhow::anyhow!("invalid summary selector: {:?}", e)))
+        .transpose()?;
+    let date_sel = date_selector
+        .map(|s| Selector::parse(s).map_err(|e| anyhow::anyhow!("invalid date selector: {:?}", e)))
+        .transpose()?;
+
+    let mut results = Vec::new();
+
+    for element in document.select(&items_sel).take(limit) {
+        let title = title_sel
+            .as_ref()
+            .and_then(|sel| element.select(sel).next())
+            .map(|el| el.text().collect::<String>().trim().to_string())
+            .unwrap_or_default();
+
+        let raw_url = url_sel
+            .as_ref()
+            .and_then(|sel| element.select(sel).next())
+            .and_then(|el| el.value().attr("href").map(String::from))
+            .unwrap_or_default();
+
+        let item_url = resolve_url(&raw_url, base_url);
+
+        let summary = summary_sel
+            .as_ref()
+            .and_then(|sel| element.select(sel).next())
+            .map(|el| el.text().collect::<String>().trim().to_string())
+            .unwrap_or_default();
+
+        let published = date_sel
+            .as_ref()
+            .and_then(|sel| element.select(sel).next())
+            .and_then(|el| {
+                let text = el.text().collect::<String>();
+                let text = text.trim();
+                if let Some(fmt) = date_format {
+                    chrono::NaiveDateTime::parse_from_str(text, fmt)
+                        .ok()
+                        .map(|dt| dt.and_utc())
+                        .or_else(|| {
+                            chrono::NaiveDate::parse_from_str(text, fmt)
+                                .ok()
+                                .map(|d| d.and_hms_opt(0, 0, 0).unwrap().and_utc())
+                        })
+                } else {
+                    chrono::DateTime::parse_from_rfc3339(text)
+                        .ok()
+                        .map(|dt| dt.with_timezone(&chrono::Utc))
+                        .or_else(|| {
+                            chrono::DateTime::parse_from_rfc2822(text)
+                                .ok()
+                                .map(|dt| dt.with_timezone(&chrono::Utc))
+                        })
+                }
+            });
+
+        if title.is_empty() && item_url.is_empty() {
+            continue;
+        }
+
+        results.push(ContentItem {
+            title,
+            url: item_url,
+            summary,
+            published,
+            image_url: None,
+        });
+    }
+
+    Ok(results)
+}
+
+fn resolve_url(raw: &str, base_url: Option<&str>) -> String {
+    if raw.is_empty() {
+        return String::new();
+    }
+    if raw.starts_with("http://") || raw.starts_with("https://") {
+        return raw.to_string();
+    }
+    if let Some(base) = base_url {
+        let base = base.trim_end_matches('/');
+        if raw.starts_with('/') {
+            format!("{base}{raw}")
+        } else {
+            format!("{base}/{raw}")
+        }
+    } else {
+        raw.to_string()
+    }
+}
+
+/// Simple full-page text fetcher for `WebScrape` source variant.
+/// Strips all HTML tags and returns the page body as a single ContentItem.
+pub async fn fetch_page_text(client: &reqwest::Client, url: &str) -> Result<Vec<ContentItem>> {
+    let html = client
+        .get(url)
+        .header("User-Agent", "Mozilla/5.0 (compatible; Cthulu/1.0)")
+        .timeout(std::time::Duration::from_secs(30))
+        .send()
+        .await
+        .context("failed to fetch page")?
+        .error_for_status()
+        .with_context(|| format!("page returned error status: {url}"))?
+        .text()
+        .await
+        .context("failed to read page body")?;
+
+    let title = extract_title(&html).unwrap_or_else(|| url.to_string());
+    let body = strip_html(&html);
+
+    Ok(vec![ContentItem {
+        title,
+        url: url.to_string(),
+        summary: body,
+        published: None,
+        image_url: None,
+    }])
+}
+
+fn extract_title(html: &str) -> Option<String> {
+    let lower = html.to_lowercase();
+    let start = lower.find("<title")?;
+    let tag_close = lower[start..].find('>')?;
+    let content_start = start + tag_close + 1;
+    let end = lower[content_start..].find("</title>")?;
+    let title = html[content_start..content_start + end].trim().to_string();
+    if title.is_empty() { None } else { Some(title) }
+}
+
+fn strip_html(html: &str) -> String {
+    let document = Html::parse_document(html);
+    let body_sel = Selector::parse("body").unwrap();
+    let script_sel = Selector::parse("script, style, noscript").unwrap();
+
+    let text = document
+        .select(&body_sel)
+        .next()
+        .map(|body| {
+            let script_ids: std::collections::HashSet<_> = body
+                .select(&script_sel)
+                .map(|el| el.id())
+                .collect();
+            body.descendants()
+                .filter_map(|node| {
+                    if let scraper::node::Node::Text(t) = node.value() {
+                        // Skip text inside script/style
+                        let dominated = node.ancestors().any(|a| script_ids.contains(&a.id()));
+                        if dominated { None } else { Some(t.text.as_ref()) }
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .unwrap_or_default();
+
+    // Collapse whitespace
+    let collapsed: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    // Cap at 50k chars
+    if collapsed.len() > 50_000 {
+        collapsed[..50_000].to_string()
+    } else {
+        collapsed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE_HTML: &str = r#"
+    <html>
+    <body>
+        <div class="press-release">
+            <h3><a href="/news/release/2024-01">SEC Approves Spot Bitcoin ETF</a></h3>
+            <p class="summary">The SEC has approved multiple spot Bitcoin ETF applications.</p>
+            <span class="date">2024-01-10</span>
+        </div>
+        <div class="press-release">
+            <h3><a href="https://example.com/news/2">CFTC Issues Guidance on DeFi</a></h3>
+            <p class="summary">New guidance clarifies CFTC jurisdiction over DeFi protocols.</p>
+            <span class="date">2024-01-11</span>
+        </div>
+        <div class="press-release">
+            <h3><a href="/news/release/2024-03">Treasury Report on Stablecoins</a></h3>
+            <p class="summary">Treasury releases comprehensive stablecoin risk assessment.</p>
+            <span class="date">2024-01-12</span>
+        </div>
+    </body>
+    </html>
+    "#;
+
+    #[test]
+    fn test_parse_page_basic() {
+        let items = parse_page(
+            FIXTURE_HTML,
+            "div.press-release",
+            Some("h3"),
+            Some("h3 a"),
+            Some("p.summary"),
+            None,
+            None,
+            10,
+            Some("https://www.sec.gov"),
+        )
+        .unwrap();
+
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0].title, "SEC Approves Spot Bitcoin ETF");
+        assert_eq!(items[0].url, "https://www.sec.gov/news/release/2024-01");
+        assert_eq!(
+            items[0].summary,
+            "The SEC has approved multiple spot Bitcoin ETF applications."
+        );
+    }
+
+    #[test]
+    fn test_parse_page_absolute_url_preserved() {
+        let items = parse_page(
+            FIXTURE_HTML,
+            "div.press-release",
+            Some("h3"),
+            Some("h3 a"),
+            None,
+            None,
+            None,
+            10,
+            Some("https://www.sec.gov"),
+        )
+        .unwrap();
+
+        // Second item has absolute URL, should not be prefixed
+        assert_eq!(items[1].url, "https://example.com/news/2");
+    }
+
+    #[test]
+    fn test_parse_page_limit() {
+        let items = parse_page(
+            FIXTURE_HTML,
+            "div.press-release",
+            Some("h3"),
+            Some("h3 a"),
+            None,
+            None,
+            None,
+            2,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_page_with_date() {
+        let items = parse_page(
+            FIXTURE_HTML,
+            "div.press-release",
+            Some("h3"),
+            Some("h3 a"),
+            None,
+            Some("span.date"),
+            Some("%Y-%m-%d"),
+            10,
+            None,
+        )
+        .unwrap();
+
+        assert!(items[0].published.is_some());
+        assert_eq!(
+            items[0].published.unwrap().format("%Y-%m-%d").to_string(),
+            "2024-01-10"
+        );
+    }
+
+    #[test]
+    fn test_resolve_url_absolute() {
+        assert_eq!(
+            resolve_url("https://example.com/page", Some("https://base.com")),
+            "https://example.com/page"
+        );
+    }
+
+    #[test]
+    fn test_resolve_url_relative() {
+        assert_eq!(
+            resolve_url("/path/page", Some("https://base.com")),
+            "https://base.com/path/page"
+        );
+    }
+
+    #[test]
+    fn test_resolve_url_no_base() {
+        assert_eq!(resolve_url("/path/page", None), "/path/page");
+    }
+
+    #[test]
+    fn test_resolve_url_empty() {
+        assert_eq!(resolve_url("", Some("https://base.com")), "");
+    }
+
+    #[test]
+    fn test_invalid_selector() {
+        let result = parse_page(
+            FIXTURE_HTML,
+            "[[[invalid",
+            None,
+            None,
+            None,
+            None,
+            None,
+            10,
+            None,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_strip_html_basic() {
+        let html = "<html><body><p>Hello <b>world</b></p></body></html>";
+        let result = strip_html(html);
+        assert_eq!(result, "Hello world");
+    }
+
+    #[test]
+    fn test_strip_html_removes_tags() {
+        let html = "<html><body><p>Before</p><div class='big'>Middle</div><p>After</p></body></html>";
+        let result = strip_html(html);
+        assert!(result.contains("Before"));
+        assert!(result.contains("Middle"));
+        assert!(result.contains("After"));
+        assert!(!result.contains("<p>"));
+        assert!(!result.contains("<div"));
+    }
+
+    #[test]
+    fn test_strip_html_caps_at_50k() {
+        let long_text = "a ".repeat(30_000);
+        let html = format!("<html><body>{long_text}</body></html>");
+        let result = strip_html(&html);
+        assert!(result.len() <= 50_000);
+    }
+
+    #[test]
+    fn test_extract_title_basic() {
+        let html = "<html><head><title>My Page</title></head><body></body></html>";
+        assert_eq!(extract_title(html), Some("My Page".to_string()));
+    }
+
+    #[test]
+    fn test_extract_title_missing() {
+        let html = "<html><head></head><body></body></html>";
+        assert_eq!(extract_title(html), None);
+    }
+
+    #[test]
+    fn test_extract_title_empty() {
+        let html = "<html><head><title></title></head><body></body></html>";
+        assert_eq!(extract_title(html), None);
+    }
+}

--- a/src/tasks/triggers/cron.rs
+++ b/src/tasks/triggers/cron.rs
@@ -250,7 +250,7 @@ pub fn format_items(items: &[ContentItem]) -> String {
                 .unwrap_or_default();
 
             format!(
-                "{}. **{}**\n   URL: {}\n   Published: {}{}\n   {}\n",
+                "{}. [{}]({})\n   Published: {}{}\n   {}\n",
                 i + 1,
                 item.title,
                 item.url,
@@ -318,8 +318,8 @@ mod tests {
             },
         ];
         let result = format_items(&items);
-        assert!(result.contains("1. **Bitcoin Hits ATH**"));
-        assert!(result.contains("2. **ETH Update**"));
+        assert!(result.contains("1. [Bitcoin Hits ATH](https://example.com/1)"));
+        assert!(result.contains("2. [ETH Update](https://example.com/2)"));
         assert!(result.contains("https://example.com/1"));
         // Item without image_url should not have Image: line
         assert!(!result.contains("Image: https://example.com/1"));


### PR DESCRIPTION
## Summary

- **Web Scraper sources** — `WebScrape` (simple text extraction + keyword filter) and `WebScraper` (CSS selector-based with `scraper` crate) for government/regulatory sites without RSS
- **Keyword Filter node** — new `NodeType::Filter` with configurable AND/OR matching, field selection (title/summary/both), visible in Studio as orange nodes
- **Structured logging** — `tracing-tree` replaces `fmt` layer for hierarchical, span-aware output. Flow runs nest under `flow_run{flow=X run=Y}` spans. Noisy per-source/tool-call logs moved to debug level
- **TOML import sync** — new tasks imported on every server restart (not just first boot)
- **Studio updates** — FilterNode component, PropertyPanel forms for all new node types, `append_system_prompt` configurable on executors
- **Example configs** — crypto news prompt templates, example TOML + flow JSON, `crypto-news-asia` task in cthulu.toml

## Test plan

- [x] `cargo test` — 180 tests passing
- [x] `cargo build` — clean (only pre-existing warnings)
- [ ] Manual flow trigger to verify structured log output
- [ ] Verify new nodes appear in Studio sidebar and PropertyPanel renders forms correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)