### PR TITLE
feat: real-time run status streaming via SSE

### DIFF
--- a/cthulu-studio/src/api/runStream.ts
+++ b/cthulu-studio/src/api/runStream.ts
@@ -1,0 +1,38 @@
+import type { RunEvent } from "../types/flow";
+import { getServerUrl } from "./client";
+
+export function subscribeToRuns(
+  flowId: string,
+  onEvent: (event: RunEvent) => void,
+  onError?: (err: Event) => void
+): () => void {
+  const url = `${getServerUrl()}/api/flows/${flowId}/runs/live`;
+  const es = new EventSource(url);
+
+  const eventTypes = [
+    "run_started",
+    "node_started",
+    "node_completed",
+    "node_failed",
+    "run_completed",
+    "run_failed",
+    "log",
+  ];
+
+  for (const type of eventTypes) {
+    es.addEventListener(type, (e: MessageEvent) => {
+      try {
+        const data: RunEvent = JSON.parse(e.data);
+        onEvent(data);
+      } catch {
+        // ignore parse errors
+      }
+    });
+  }
+
+  if (onError) {
+    es.onerror = onError;
+  }
+
+  return () => es.close();
+}

--- a/cthulu-studio/src/components/Canvas.tsx
+++ b/cthulu-studio/src/components/Canvas.tsx
@@ -102,10 +102,11 @@ interface CanvasProps {
   initialFlow: Flow | null;
   onFlowSnapshot: (snapshot: { nodes: FlowNode[]; edges: FlowEdge[] }) => void;
   onSelectionChange: (nodeId: string | null) => void;
+  nodeRunStatus?: Record<string, "running" | "completed" | "failed">;
 }
 
 const Canvas = forwardRef<CanvasHandle, CanvasProps>(function Canvas(
-  { flowId, initialFlow, onFlowSnapshot, onSelectionChange },
+  { flowId, initialFlow, onFlowSnapshot, onSelectionChange, nodeRunStatus },
   ref
 ) {
   const [nodes, setNodes, onNodesChange] = useNodesState<RFNode>([]);
@@ -127,6 +128,18 @@ const Canvas = forwardRef<CanvasHandle, CanvasProps>(function Canvas(
       setEdges([]);
     }
   }, [flowId, initialFlow, setNodes, setEdges]);
+
+  // --- Merge run status into node data ---
+  useEffect(() => {
+    if (!nodeRunStatus) return;
+    setNodes((nds) =>
+      nds.map((n) => {
+        const status = nodeRunStatus[n.id] ?? null;
+        if (n.data.runStatus === status) return n;
+        return { ...n, data: { ...n.data, runStatus: status } };
+      })
+    );
+  }, [nodeRunStatus, setNodes]);
 
   // --- Snapshot emission (debounced) ---
   useEffect(() => {

--- a/cthulu-studio/src/components/NodeTypes/ExecutorNode.tsx
+++ b/cthulu-studio/src/components/NodeTypes/ExecutorNode.tsx
@@ -4,11 +4,12 @@ interface ExecutorNodeData {
   label: string;
   kind: string;
   config: Record<string, unknown>;
+  runStatus?: "running" | "completed" | "failed" | null;
 }
 
 export default function ExecutorNode({ data }: { data: ExecutorNodeData }) {
   return (
-    <div className="custom-node">
+    <div className={`custom-node${data.runStatus ? ` run-${data.runStatus}` : ""}`}>
       <Handle id="in" type="target" position={Position.Left} />
       <div className="node-header">
         <span className="node-type-badge executor">Executor</span>

--- a/cthulu-studio/src/components/NodeTypes/FilterNode.tsx
+++ b/cthulu-studio/src/components/NodeTypes/FilterNode.tsx
@@ -4,11 +4,12 @@ interface FilterNodeData {
   label: string;
   kind: string;
   config: Record<string, unknown>;
+  runStatus?: "running" | "completed" | "failed" | null;
 }
 
 export default function FilterNode({ data }: { data: FilterNodeData }) {
   return (
-    <div className="custom-node">
+    <div className={`custom-node${data.runStatus ? ` run-${data.runStatus}` : ""}`}>
       <Handle id="in" type="target" position={Position.Left} />
       <div className="node-header">
         <span className="node-type-badge filter">Filter</span>

--- a/cthulu-studio/src/components/NodeTypes/SinkNode.tsx
+++ b/cthulu-studio/src/components/NodeTypes/SinkNode.tsx
@@ -4,11 +4,12 @@ interface SinkNodeData {
   label: string;
   kind: string;
   config: Record<string, unknown>;
+  runStatus?: "running" | "completed" | "failed" | null;
 }
 
 export default function SinkNode({ data }: { data: SinkNodeData }) {
   return (
-    <div className="custom-node">
+    <div className={`custom-node${data.runStatus ? ` run-${data.runStatus}` : ""}`}>
       <Handle id="in" type="target" position={Position.Left} />
       <div className="node-header">
         <span className="node-type-badge sink">Sink</span>

--- a/cthulu-studio/src/components/NodeTypes/SourceNode.tsx
+++ b/cthulu-studio/src/components/NodeTypes/SourceNode.tsx
@@ -4,11 +4,12 @@ interface SourceNodeData {
   label: string;
   kind: string;
   config: Record<string, unknown>;
+  runStatus?: "running" | "completed" | "failed" | null;
 }
 
 export default function SourceNode({ data }: { data: SourceNodeData }) {
   return (
-    <div className="custom-node">
+    <div className={`custom-node${data.runStatus ? ` run-${data.runStatus}` : ""}`}>
       <Handle id="in" type="target" position={Position.Left} />
       <div className="node-header">
         <span className="node-type-badge source">Source</span>

--- a/cthulu-studio/src/components/NodeTypes/TriggerNode.tsx
+++ b/cthulu-studio/src/components/NodeTypes/TriggerNode.tsx
@@ -4,11 +4,12 @@ interface TriggerNodeData {
   label: string;
   kind: string;
   config: Record<string, unknown>;
+  runStatus?: "running" | "completed" | "failed" | null;
 }
 
 export default function TriggerNode({ data }: { data: TriggerNodeData }) {
   return (
-    <div className="custom-node">
+    <div className={`custom-node${data.runStatus ? ` run-${data.runStatus}` : ""}`}>
       <div className="node-header">
         <span className="node-type-badge trigger">Trigger</span>
       </div>

--- a/cthulu-studio/src/components/RunLog.tsx
+++ b/cthulu-studio/src/components/RunLog.tsx
@@ -1,0 +1,162 @@
+import { useState, useEffect, useRef } from "react";
+import type { RunEvent } from "../types/flow";
+
+const EVENT_COLORS: Record<string, string> = {
+  run_started: "var(--accent)",
+  node_started: "var(--accent)",
+  node_completed: "#3fb950",
+  node_failed: "var(--danger)",
+  run_completed: "#3fb950",
+  run_failed: "var(--danger)",
+  log: "var(--text-secondary)",
+};
+
+const EVENT_LABELS: Record<string, string> = {
+  run_started: "START",
+  node_started: "NODE",
+  node_completed: "DONE",
+  node_failed: "FAIL",
+  run_completed: "DONE",
+  run_failed: "FAIL",
+  log: "LOG",
+};
+
+interface RunLogProps {
+  events: RunEvent[];
+  onClear: () => void;
+  onClose: () => void;
+}
+
+export default function RunLog({ events, onClear, onClose }: RunLogProps) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const [autoScroll, setAutoScroll] = useState(true);
+
+  useEffect(() => {
+    if (autoScroll && bottomRef.current) {
+      bottomRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [events, autoScroll]);
+
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+    setAutoScroll(atBottom);
+  };
+
+  // Group entries by run_id for display
+  const runIds = [...new Set(events.map((e) => e.run_id))];
+  const latestRunId = runIds[runIds.length - 1];
+  const [collapsedRuns, setCollapsedRuns] = useState<Set<string>>(new Set());
+
+  const toggleRun = (runId: string) => {
+    setCollapsedRuns((prev) => {
+      const next = new Set(prev);
+      if (next.has(runId)) next.delete(runId);
+      else next.add(runId);
+      return next;
+    });
+  };
+
+  const formatTime = (ts: string) => {
+    const d = new Date(ts);
+    const h = String(d.getHours()).padStart(2, "0");
+    const m = String(d.getMinutes()).padStart(2, "0");
+    const s = String(d.getSeconds()).padStart(2, "0");
+    const ms = String(d.getMilliseconds()).padStart(3, "0");
+    return `${h}:${m}:${s}.${ms}`;
+  };
+
+  return (
+    <div className="console-panel run-log-panel">
+      <div className="console-header">
+        <span className="console-title">Run Log</span>
+        <div className="spacer" />
+        <button className="ghost console-btn" onClick={onClear}>
+          Clear
+        </button>
+        <button className="ghost console-btn" onClick={onClose}>
+          Close
+        </button>
+      </div>
+      <div className="console-body" onScroll={handleScroll}>
+        {events.length === 0 && (
+          <div className="console-empty">
+            Waiting for run events...
+          </div>
+        )}
+        {runIds.map((runId) => {
+          const runEntries = events.filter((e) => e.run_id === runId);
+          const isCollapsed = collapsedRuns.has(runId) && runId !== latestRunId;
+          const startEvent = runEntries[0];
+          const endEvent = runEntries.find(
+            (e) =>
+              e.event_type === "run_completed" ||
+              e.event_type === "run_failed"
+          );
+
+          return (
+            <div key={runId}>
+              <div
+                className="run-log-group-header"
+                onClick={() => toggleRun(runId)}
+              >
+                <span className="run-log-chevron">
+                  {isCollapsed ? "\u25b6" : "\u25bc"}
+                </span>
+                <span className="console-time">
+                  {formatTime(startEvent.timestamp)}
+                </span>
+                <span
+                  className="run-log-badge"
+                  style={{
+                    color: endEvent
+                      ? EVENT_COLORS[endEvent.event_type]
+                      : "var(--accent)",
+                  }}
+                >
+                  {endEvent
+                    ? endEvent.event_type === "run_completed"
+                      ? "COMPLETED"
+                      : "FAILED"
+                    : "RUNNING"}
+                </span>
+                <span className="run-log-run-id">
+                  {runId.slice(0, 8)}
+                </span>
+                {isCollapsed && (
+                  <span className="run-log-summary">
+                    {runEntries.length} events
+                    {endEvent ? ` \u2014 ${endEvent.message}` : ""}
+                  </span>
+                )}
+              </div>
+              {!isCollapsed &&
+                runEntries.map((entry, i) => (
+                  <div
+                    key={`${runId}-${i}`}
+                    className={`console-entry run-log-entry run-log-${entry.event_type.includes("failed") ? "failed" : entry.event_type.includes("completed") ? "completed" : "default"}`}
+                  >
+                    <span className="console-time">
+                      {formatTime(entry.timestamp)}
+                    </span>
+                    <span
+                      className="run-log-badge"
+                      style={{
+                        color: EVENT_COLORS[entry.event_type] || "var(--text-secondary)",
+                      }}
+                    >
+                      {EVENT_LABELS[entry.event_type] || entry.event_type}
+                    </span>
+                    <span className="console-message">
+                      {entry.message}
+                    </span>
+                  </div>
+                ))}
+            </div>
+          );
+        })}
+        <div ref={bottomRef} />
+      </div>
+    </div>
+  );
+}

--- a/cthulu-studio/src/components/TopBar.tsx
+++ b/cthulu-studio/src/components/TopBar.tsx
@@ -8,6 +8,8 @@ interface TopBarProps {
   onSettingsClick: () => void;
   consoleOpen: boolean;
   onToggleConsole: () => void;
+  runLogOpen: boolean;
+  onToggleRunLog: () => void;
   errorCount: number;
 }
 
@@ -18,6 +20,8 @@ export default function TopBar({
   onSettingsClick,
   consoleOpen,
   onToggleConsole,
+  runLogOpen,
+  onToggleRunLog,
   errorCount,
 }: TopBarProps) {
   const [connected, setConnected] = useState(false);
@@ -75,6 +79,12 @@ export default function TopBar({
         />
         <span>{connected ? api.getServerUrl() : "Disconnected"}</span>
       </div>
+      <button
+        className={`ghost ${runLogOpen ? "console-toggle-active" : ""}`}
+        onClick={onToggleRunLog}
+      >
+        Log
+      </button>
       <button
         className={`ghost ${consoleOpen ? "console-toggle-active" : ""}`}
         onClick={onToggleConsole}

--- a/cthulu-studio/src/styles.css
+++ b/cthulu-studio/src/styles.css
@@ -453,6 +453,28 @@ button:disabled {
   stroke-width: 3 !important;
 }
 
+/* Node run status highlights */
+.custom-node.run-running {
+  border-color: var(--accent);
+  box-shadow: 0 0 8px rgba(88, 166, 255, 0.4);
+  animation: pulse-running 1.5s ease-in-out infinite;
+}
+
+.custom-node.run-completed {
+  border-color: #3fb950;
+  box-shadow: 0 0 8px rgba(63, 185, 80, 0.35);
+}
+
+.custom-node.run-failed {
+  border-color: var(--danger);
+  box-shadow: 0 0 8px rgba(248, 81, 73, 0.4);
+}
+
+@keyframes pulse-running {
+  0%, 100% { box-shadow: 0 0 8px rgba(88, 166, 255, 0.4); }
+  50% { box-shadow: 0 0 16px rgba(88, 166, 255, 0.7); }
+}
+
 .react-flow__node.selected .custom-node {
   border-color: var(--accent);
   box-shadow: 0 0 0 1px var(--accent);
@@ -694,6 +716,67 @@ button:disabled {
 
 .app-with-console .app-layout {
   height: calc(100vh - 48px - 280px);
+}
+
+/* Run Log */
+.run-log-panel {
+  height: 280px;
+}
+
+.run-log-group-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 12px;
+  font-size: 11px;
+  cursor: pointer;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  user-select: none;
+}
+
+.run-log-group-header:hover {
+  background: var(--bg-tertiary);
+}
+
+.run-log-chevron {
+  font-size: 9px;
+  color: var(--text-secondary);
+  width: 10px;
+  flex-shrink: 0;
+}
+
+.run-log-badge {
+  flex-shrink: 0;
+  font-weight: 600;
+  font-size: 10px;
+  width: 40px;
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+}
+
+.run-log-run-id {
+  color: var(--text-secondary);
+  opacity: 0.6;
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  font-size: 10px;
+}
+
+.run-log-summary {
+  color: var(--text-secondary);
+  font-size: 11px;
+  margin-left: 4px;
+}
+
+.run-log-entry.run-log-failed {
+  background: rgba(248, 81, 73, 0.06);
+}
+
+.run-log-entry.run-log-completed {
+  background: rgba(63, 185, 80, 0.04);
+}
+
+.console-toggle-active {
+  color: var(--accent) !important;
 }
 
 /* Drag ghost */

--- a/cthulu-studio/src/types/flow.ts
+++ b/cthulu-studio/src/types/flow.ts
@@ -68,3 +68,12 @@ export interface NodeTypeSchema {
   label: string;
   config_schema: Record<string, unknown>;
 }
+
+export interface RunEvent {
+  flow_id: string;
+  run_id: string;
+  timestamp: string;
+  node_id: string | null;
+  event_type: string;
+  message: string;
+}

--- a/src/flows/events.rs
+++ b/src/flows/events.rs
@@ -1,0 +1,38 @@
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RunEvent {
+    pub flow_id: String,
+    pub run_id: String,
+    pub timestamp: DateTime<Utc>,
+    pub node_id: Option<String>,
+    pub event_type: RunEventType,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunEventType {
+    RunStarted,
+    NodeStarted,
+    NodeCompleted,
+    NodeFailed,
+    RunCompleted,
+    RunFailed,
+    Log,
+}
+
+impl RunEventType {
+    pub fn as_sse_event(&self) -> &'static str {
+        match self {
+            RunEventType::RunStarted => "run_started",
+            RunEventType::NodeStarted => "node_started",
+            RunEventType::NodeCompleted => "node_completed",
+            RunEventType::NodeFailed => "node_failed",
+            RunEventType::RunCompleted => "run_completed",
+            RunEventType::RunFailed => "run_failed",
+            RunEventType::Log => "log",
+        }
+    }
+}

--- a/src/flows/mod.rs
+++ b/src/flows/mod.rs
@@ -1,3 +1,4 @@
+pub mod events;
 pub mod file_store;
 pub mod history;
 pub mod runner;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,7 +3,9 @@ pub mod middleware;
 pub mod routes;
 
 use axum::Router;
+use tokio::sync::broadcast;
 
+use crate::flows::events::RunEvent;
 use crate::flows::scheduler::FlowScheduler;
 use crate::flows::store::Store;
 use crate::github::client::GithubClient;
@@ -15,6 +17,7 @@ pub struct AppState {
     pub http_client: Arc<reqwest::Client>,
     pub store: Arc<dyn Store>,
     pub scheduler: Arc<FlowScheduler>,
+    pub events_tx: broadcast::Sender<RunEvent>,
 }
 
 pub fn create_app(state: AppState) -> Router {


### PR DESCRIPTION
## Summary
- **Server:** Adds a `broadcast::channel<RunEvent>` on `AppState`, emits events at each runner pipeline stage (source fetch, filter, prompt render, executor, sink delivery), and exposes `GET /api/flows/{id}/runs/live` as an SSE endpoint filtered by flow ID
- **Studio:** Subscribes via `EventSource`, displays a collapsible **Run Log** panel with timestamped color-coded entries grouped by run, and highlights graph nodes in real-time — pulsing blue for running, green glow for completed, red for failed
- **Canvas highlighting** persists for 10s after run finishes, resets on next run start

## Test plan
- [ ] `cargo check` + `cargo test` pass (146 tests)
- [ ] Start server, open Studio, select a flow
- [ ] Open devtools Network → verify SSE connection to `/api/flows/{id}/runs/live`
- [ ] Click "Run" → RunLog auto-opens, events stream in real-time
- [ ] Verify canvas nodes glow blue while executing, turn green on completion
- [ ] Click "Log" toggle in TopBar to show/hide the RunLog panel
- [ ] Trigger second run → new entries appear, first run collapses
- [ ] Switch flows → SSE reconnects, node statuses reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)