### PR TITLE
feat: Session Info panel with agent config, stats, and controls

### DIFF
--- a/cthulu-backend/api/agents/chat.rs
+++ b/cthulu-backend/api/agents/chat.rs
@@ -358,6 +358,10 @@ pub(crate) async fn session_status(
         "process_alive": process_alive,
         "message_count": session.message_count,
         "total_cost": session.total_cost,
+        "created_at": session.created_at,
+        "working_dir": session.working_dir,
+        "worktree_group": session.worktree_group,
+        "skills_dir": session.skills_dir,
     })))
 }
 

--- a/cthulu-studio/src/api/client.ts
+++ b/cthulu-studio/src/api/client.ts
@@ -213,6 +213,19 @@ export async function stopAgentChat(
   });
 }
 
+export interface WorktreeEntryMeta {
+  repo_root: string;
+  worktree_path: string;
+  branch: string;
+}
+
+export interface WorktreeGroupMeta {
+  shadow_root: string;
+  source_dir: string;
+  single_repo: boolean;
+  repos: WorktreeEntryMeta[];
+}
+
 export interface SessionStatus {
   session_id: string;
   busy: boolean;
@@ -220,6 +233,10 @@ export interface SessionStatus {
   process_alive: boolean;
   message_count: number;
   total_cost: number;
+  created_at: string | null;
+  working_dir: string | null;
+  worktree_group: WorktreeGroupMeta | null;
+  skills_dir: string | null;
 }
 
 export async function getSessionStatus(

--- a/cthulu-studio/src/components/AgentDetailView.tsx
+++ b/cthulu-studio/src/components/AgentDetailView.tsx
@@ -1,9 +1,10 @@
-import { useState, useRef, useCallback, useMemo } from "react";
+import { useState, useRef, useCallback, useMemo, useEffect } from "react";
 import AgentChatView, { useAgentChat } from "./AgentChatView";
 import FileViewer from "./FileViewer";
 import DebugPanel from "./DebugPanel";
 import ChangesPanel from "./ChangesPanel";
 import SessionInfoPanel from "./SessionInfoPanel";
+import { getSessionStatus } from "../api/client";
 import type { PendingPermission, FileChangeData } from "../hooks/useGlobalPermissions";
 import type { DebugEvent } from "./chat/useAgentChat";
 
@@ -40,6 +41,21 @@ export default function AgentDetailView({
   const [filesFlex, setFilesFlex] = useState(1);
   const [referenceTab, setReferenceTab] = useState<ReferenceTab>("files");
   const containerRef = useRef<HTMLDivElement>(null);
+  const [infoBadge, setInfoBadge] = useState(0);
+
+  // Poll session status for info badge (message count)
+  useEffect(() => {
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const s = await getSessionStatus(agentId, sessionId);
+        if (!cancelled) setInfoBadge(s.message_count);
+      } catch { /* ignore */ }
+    };
+    poll();
+    const interval = setInterval(poll, 5000);
+    return () => { cancelled = true; clearInterval(interval); };
+  }, [agentId, sessionId]);
 
   // Derive hookChangedFiles from fileChanges filtered by this agent/session
   const hookChangedFiles = useMemo(() => {
@@ -158,6 +174,9 @@ export default function AgentDetailView({
             <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
               <path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1zm0 1a6 6 0 1 1 0 12A6 6 0 0 1 8 2zm-.5 3h1v1h-1V5zm0 2h1v5h-1V7z"/>
             </svg>
+            {infoBadge > 0 && referenceTab !== "info" && (
+              <span className="ref-toolbar-badge">{infoBadge}</span>
+            )}
           </button>
         </div>
       </div>

--- a/cthulu-studio/src/components/AgentDetailView.tsx
+++ b/cthulu-studio/src/components/AgentDetailView.tsx
@@ -3,10 +3,11 @@ import AgentChatView, { useAgentChat } from "./AgentChatView";
 import FileViewer from "./FileViewer";
 import DebugPanel from "./DebugPanel";
 import ChangesPanel from "./ChangesPanel";
+import SessionInfoPanel from "./SessionInfoPanel";
 import type { PendingPermission, FileChangeData } from "../hooks/useGlobalPermissions";
 import type { DebugEvent } from "./chat/useAgentChat";
 
-export type ReferenceTab = "files" | "changes" | "debug";
+export type ReferenceTab = "files" | "changes" | "debug" | "info";
 
 interface AgentDetailViewProps {
   agentId: string;
@@ -31,7 +32,7 @@ export default function AgentDetailView({
   onPermissionResponse,
   hookDebugEvents,
   onClearHookDebug,
-  onDeleted: _onDeleted,
+  onDeleted,
   fileChanges,
 }: AgentDetailViewProps) {
   const chat = useAgentChat(agentId, sessionId);
@@ -106,12 +107,18 @@ export default function AgentDetailView({
               gitSnapshot={chat.gitSnapshot}
               hookChangedFiles={hookChangedFiles}
             />
-          ) : (
+          ) : referenceTab === "debug" ? (
             <DebugPanel
               chatEvents={chat.debugEvents}
               hookEvents={hookDebugEvents}
               onClearChat={chat.clearDebugEvents}
               onClearHook={onClearHookDebug}
+            />
+          ) : (
+            <SessionInfoPanel
+              agentId={agentId}
+              sessionId={sessionId}
+              onSessionDeleted={onDeleted}
             />
           )}
         </div>
@@ -141,6 +148,15 @@ export default function AgentDetailView({
           >
             <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
               <path d="M4.5 3A2.5 2.5 0 0 1 7 .5h2A2.5 2.5 0 0 1 11.5 3v.07a5 5 0 0 1 2.18 1.49l1.82-1.06.5.87-1.81 1.04A5 5 0 0 1 14.5 7H16v1h-1.5a5 5 0 0 1-.31 1.59l1.81 1.04-.5.87-1.82-1.06A5 5 0 0 1 11.5 12v1a2.5 2.5 0 0 1-2.5 2.5H7A2.5 2.5 0 0 1 4.5 13v-1a5 5 0 0 1-2.18-1.56L.5 11.5l-.5-.87 1.81-1.04A5 5 0 0 1 1.5 8H0V7h1.5a5 5 0 0 1 .31-1.59L.5 4.37l.5-.87 1.82 1.06A5 5 0 0 1 4.5 3.07V3zm1 0v.34l-.44.2A4 4 0 0 0 4 8a4 4 0 0 0 1.06 2.71l.44.42V13A1.5 1.5 0 0 0 7 14.5h2a1.5 1.5 0 0 0 1.5-1.5v-1.87l.44-.42A4 4 0 0 0 12 8a4 4 0 0 0-1.06-2.46l-.44-.2V3A1.5 1.5 0 0 0 9 1.5H7A1.5 1.5 0 0 0 5.5 3z"/>
+            </svg>
+          </button>
+          <button
+            className={`ref-toolbar-btn ${referenceTab === "info" ? "ref-toolbar-btn-active" : ""}`}
+            onClick={() => setReferenceTab("info")}
+            title="Session Info"
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1zm0 1a6 6 0 1 1 0 12A6 6 0 0 1 8 2zm-.5 3h1v1h-1V5zm0 2h1v5h-1V7z"/>
             </svg>
           </button>
         </div>

--- a/cthulu-studio/src/components/SessionInfoPanel.tsx
+++ b/cthulu-studio/src/components/SessionInfoPanel.tsx
@@ -1,10 +1,18 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import ShikiHighlighter from "react-shiki";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { useTheme } from "@/lib/ThemeContext";
 import {
   getAgent,
   getSessionStatus,
   killSession,
   deleteAgentSession,
+  updateAgent,
+  readSessionFile,
+  listSessionFiles,
   type SessionStatus,
+  type FileTreeEntry,
 } from "../api/client";
 import type { Agent } from "../types/flow";
 
@@ -14,19 +22,70 @@ interface SessionInfoPanelProps {
   onSessionDeleted: () => void;
 }
 
+const KNOWN_PERMISSIONS = [
+  "Bash", "Read", "Write", "Edit", "Glob", "Grep",
+  "WebFetch", "WebSearch", "NotebookEdit",
+];
+
+// Navigation items for the left sidebar
+type NavId =
+  | "overview"
+  | "prompts/agent"
+  | "prompts/system"
+  | `skills/${string}`
+  | `config/${string}`;
+
+interface NavItem {
+  id: NavId;
+  label: string;
+  depth: number;
+  isFolder?: boolean;
+  icon?: string;
+}
+
+// Config files to look for in the working directory
+const CONFIG_FILES = ["AGENT.md", "CLAUDE.md", ".claude/settings.json"];
+
 export default function SessionInfoPanel({
   agentId,
   sessionId,
   onSessionDeleted,
 }: SessionInfoPanelProps) {
+  const { theme: appTheme } = useTheme();
   const [agent, setAgent] = useState<Agent | null>(null);
   const [status, setStatus] = useState<SessionStatus | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [killing, setKilling] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [selected, setSelected] = useState<NavId>("overview");
+  const [treeWidth, setTreeWidth] = useState(160);
 
-  // Fetch agent + session status on mount and periodically
+  // Inline editing
+  const [editingField, setEditingField] = useState<"name" | "working_dir" | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const editInputRef = useRef<HTMLInputElement>(null);
+  const [editingPerms, setEditingPerms] = useState(false);
+  const [draftPerms, setDraftPerms] = useState<string[]>([]);
+
+  // Copy feedback
+  const [copied, setCopied] = useState(false);
+
+  // Skills files discovered from the file tree
+  const [skillsFiles, setSkillsFiles] = useState<string[]>([]);
+  // Config files found
+  const [configFiles, setConfigFiles] = useState<string[]>([]);
+  // File content for detail view
+  const [fileContent, setFileContent] = useState<string | null>(null);
+  const [fileLoading, setFileLoading] = useState(false);
+
+  // Expanded folders in nav
+  const [expanded, setExpanded] = useState<Set<string>>(new Set(["prompts", "skills", "config"]));
+
+  const shikiTheme = appTheme.shikiTheme;
+  const theme = { dark: shikiTheme as string, light: shikiTheme as string };
+
+  // Fetch agent + session status
   useEffect(() => {
     let cancelled = false;
     const fetchAll = async () => {
@@ -47,6 +106,97 @@ export default function SessionInfoPanel({
     const interval = setInterval(fetchAll, 5000);
     return () => { cancelled = true; clearInterval(interval); };
   }, [agentId, sessionId]);
+
+  // Discover skills files and config files from file tree
+  useEffect(() => {
+    let cancelled = false;
+    const discover = async () => {
+      try {
+        const data = await listSessionFiles(agentId, sessionId);
+        if (cancelled) return;
+
+        // Find .skills/ directory
+        const skills: string[] = [];
+        const findSkills = (entries: FileTreeEntry[], parentPath: string) => {
+          for (const e of entries) {
+            if (e.type === "directory" && e.name === ".skills" && e.children) {
+              for (const child of e.children) {
+                if (child.type === "file") {
+                  skills.push(child.path);
+                }
+              }
+            }
+            if (e.type === "directory" && e.children) {
+              findSkills(e.children, e.path);
+            }
+          }
+        };
+        findSkills(data.tree, "");
+        setSkillsFiles(skills);
+
+        // Find config files at root
+        const configs: string[] = [];
+        const rootNames = new Set(data.tree.map((e) => e.path));
+        for (const cf of CONFIG_FILES) {
+          // Check both root and nested
+          const findFile = (entries: FileTreeEntry[], target: string): string | null => {
+            for (const e of entries) {
+              if (e.type === "file" && e.path.endsWith(target)) return e.path;
+              if (e.type === "directory" && e.children) {
+                const found = findFile(e.children, target);
+                if (found) return found;
+              }
+            }
+            return null;
+          };
+          const found = findFile(data.tree, cf);
+          if (found) configs.push(found);
+        }
+        setConfigFiles(configs);
+      } catch { /* ignore */ }
+    };
+    discover();
+  }, [agentId, sessionId]);
+
+  // Load file content when selecting a file-based nav item
+  useEffect(() => {
+    if (selected === "overview") { setFileContent(null); return; }
+    if (selected === "prompts/agent" || selected === "prompts/system") {
+      setFileContent(null);
+      return;
+    }
+
+    // It's a file path (skills/... or config/...)
+    const path = selected.startsWith("skills/")
+      ? selected.slice("skills/".length)
+      : selected.startsWith("config/")
+        ? selected.slice("config/".length)
+        : null;
+
+    if (!path) return;
+
+    let cancelled = false;
+    setFileLoading(true);
+    readSessionFile(agentId, sessionId, path)
+      .then((data) => {
+        if (!cancelled) setFileContent(data.content);
+      })
+      .catch(() => {
+        if (!cancelled) setFileContent("// Error reading file");
+      })
+      .finally(() => {
+        if (!cancelled) setFileLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [selected, agentId, sessionId]);
+
+  // Focus input when editing starts
+  useEffect(() => {
+    if (editingField && editInputRef.current) {
+      editInputRef.current.focus();
+      editInputRef.current.select();
+    }
+  }, [editingField]);
 
   const handleKill = useCallback(async () => {
     setKilling(true);
@@ -73,6 +223,127 @@ export default function SessionInfoPanel({
     }
   }, [agentId, sessionId, onSessionDeleted]);
 
+  const startEdit = (field: "name" | "working_dir") => {
+    if (!agent) return;
+    setEditingField(field);
+    setEditValue(field === "name" ? agent.name : (agent.working_dir ?? ""));
+  };
+
+  const cancelEdit = () => { setEditingField(null); setEditValue(""); };
+
+  const saveEdit = async () => {
+    if (!agent || !editingField) return;
+    try {
+      const updates = editingField === "name"
+        ? { name: editValue }
+        : { working_dir: editValue || null };
+      const updated = await updateAgent(agentId, updates);
+      setAgent(updated);
+    } catch { setError("Failed to save"); }
+    setEditingField(null);
+  };
+
+  const handleEditKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") saveEdit();
+    if (e.key === "Escape") cancelEdit();
+  };
+
+  const startPermEdit = () => {
+    if (!agent) return;
+    setEditingPerms(true);
+    setDraftPerms([...agent.permissions]);
+  };
+
+  const togglePerm = (perm: string) => {
+    setDraftPerms((prev) =>
+      prev.includes(perm) ? prev.filter((p) => p !== perm) : [...prev, perm]
+    );
+  };
+
+  const savePerms = async () => {
+    if (!agent) return;
+    try {
+      const updated = await updateAgent(agentId, { permissions: draftPerms });
+      setAgent(updated);
+    } catch { setError("Failed to save permissions"); }
+    setEditingPerms(false);
+  };
+
+  const copySessionId = () => {
+    navigator.clipboard.writeText(sessionId);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const toggleFolder = (folder: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(folder)) next.delete(folder);
+      else next.add(folder);
+      return next;
+    });
+  };
+
+  // Build nav items
+  const navItems = useMemo((): NavItem[] => {
+    const items: NavItem[] = [];
+
+    items.push({ id: "overview", label: "Overview", depth: 0, icon: "ℹ" });
+
+    // Prompts folder
+    const hasPrompts = agent && (agent.prompt || agent.append_system_prompt);
+    if (hasPrompts) {
+      items.push({ id: "prompts/agent" as NavId, label: "Prompts", depth: 0, isFolder: true, icon: "📝" });
+      if (expanded.has("prompts")) {
+        if (agent!.prompt) items.push({ id: "prompts/agent", label: "Agent Prompt", depth: 1 });
+        if (agent!.append_system_prompt) items.push({ id: "prompts/system", label: "System Prompt", depth: 1 });
+      }
+    }
+
+    // Skills folder
+    if (skillsFiles.length > 0) {
+      items.push({ id: `skills/${skillsFiles[0]}` as NavId, label: "Skills", depth: 0, isFolder: true, icon: "⚡" });
+      if (expanded.has("skills")) {
+        for (const f of skillsFiles) {
+          const name = f.split("/").pop() ?? f;
+          items.push({ id: `skills/${f}` as NavId, label: name, depth: 1 });
+        }
+      }
+    }
+
+    // Config files folder
+    if (configFiles.length > 0) {
+      items.push({ id: `config/${configFiles[0]}` as NavId, label: "Config", depth: 0, isFolder: true, icon: "⚙" });
+      if (expanded.has("config")) {
+        for (const f of configFiles) {
+          const name = f.split("/").pop() ?? f;
+          items.push({ id: `config/${f}` as NavId, label: name, depth: 1 });
+        }
+      }
+    }
+
+    return items;
+  }, [agent, skillsFiles, configFiles, expanded]);
+
+  const handleTreeResize = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startW = treeWidth;
+    const onMove = (ev: MouseEvent) => {
+      setTreeWidth(Math.max(100, Math.min(300, startW + ev.clientX - startX)));
+    };
+    const onUp = () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  }, [treeWidth]);
+
   if (error && !agent && !status) {
     return (
       <div className="session-info-panel">
@@ -81,133 +352,306 @@ export default function SessionInfoPanel({
     );
   }
 
-  return (
-    <div className="session-info-panel">
-      {/* ── Session Status ── */}
-      <section className="session-info-section">
-        <h3 className="session-info-heading">Session</h3>
-        {status ? (
-          <div className="session-info-grid">
-            <Row label="Status">
-              <StatusDot alive={status.process_alive} busy={status.busy} />
-              {status.busy
-                ? "Busy"
-                : status.process_alive
-                  ? "Idle"
-                  : "Stopped"}
-            </Row>
-            <Row label="Messages">{status.message_count}</Row>
-            <Row label="Cost">
-              {status.total_cost > 0
-                ? `$${status.total_cost.toFixed(4)}`
-                : "—"}
-            </Row>
-            {status.busy_since && (
-              <Row label="Busy since">
-                {new Date(status.busy_since).toLocaleTimeString()}
-              </Row>
-            )}
-            <Row label="Session ID">
-              <span className="session-info-mono session-info-truncate">
-                {sessionId.slice(0, 12)}
-              </span>
-            </Row>
-          </div>
-        ) : (
-          <div className="session-info-loading">Loading...</div>
-        )}
-      </section>
+  const isFileView = selected !== "overview" && selected !== "prompts/agent" && selected !== "prompts/system";
+  const filePath = isFileView
+    ? selected.startsWith("skills/") ? selected.slice("skills/".length)
+      : selected.startsWith("config/") ? selected.slice("config/".length)
+      : null
+    : null;
 
-      {/* ── Agent Config ── */}
-      {agent && (
-        <section className="session-info-section">
-          <h3 className="session-info-heading">Agent</h3>
-          <div className="session-info-grid">
-            <Row label="Name">{agent.name}</Row>
-            {agent.working_dir && (
-              <Row label="Working dir">
-                <span className="session-info-mono session-info-truncate">
-                  {agent.working_dir}
-                </span>
-              </Row>
-            )}
-            <Row label="Permissions">
-              {agent.permissions.length > 0 ? (
-                <div className="session-info-tags">
-                  {agent.permissions.map((p) => (
-                    <span key={p} className="session-info-tag">{p}</span>
-                  ))}
+  const isMarkdown = filePath ? /\.md$/i.test(filePath) : false;
+
+  return (
+    <div className="fv">
+      {/* Left: nav tree */}
+      <div className="fv-tree" style={{ width: treeWidth }}>
+        <div className="fv-tree-header">
+          <span>Session Info</span>
+        </div>
+        <div className="fv-tree-scroll">
+          {navItems.map((item) => {
+            const isActive = item.id === selected ||
+              (item.isFolder && selected.startsWith(item.id.split("/")[0] === "prompts" ? "prompts/" : item.id.split("/")[0] + "/"));
+            const folderKey = item.id.split("/")[0];
+            return (
+              <div
+                key={`${item.id}-${item.isFolder ? "folder" : "item"}`}
+                className={`fv-item${isActive && !item.isFolder ? " fv-item-active" : ""}`}
+                style={{ paddingLeft: 8 + item.depth * 16 }}
+                onClick={() => {
+                  if (item.isFolder) {
+                    toggleFolder(folderKey);
+                  } else {
+                    setSelected(item.id);
+                  }
+                }}
+              >
+                {item.isFolder ? (
+                  <span className="fv-icon">
+                    {expanded.has(folderKey) ? "▾" : "▸"}
+                  </span>
+                ) : item.depth === 0 ? (
+                  <span className="fv-icon">{item.icon}</span>
+                ) : (
+                  <span className="fv-icon" style={{ fontSize: 9, opacity: 0.5 }}>•</span>
+                )}
+                <span className="fv-name">{item.label}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="fv-tree-divider" onMouseDown={handleTreeResize} />
+
+      {/* Right: detail pane */}
+      <div className="fv-content">
+        {selected === "overview" && (
+          <div className="session-info-detail">
+            {/* Session status */}
+            <section className="session-info-section">
+              <h3 className="session-info-heading">Session</h3>
+              {status ? (
+                <div className="session-info-grid">
+                  <Row label="Status">
+                    <StatusDot alive={status.process_alive} busy={status.busy} />
+                    {status.busy ? "Busy" : status.process_alive ? "Idle" : "Stopped"}
+                  </Row>
+                  <Row label="Messages">{status.message_count}</Row>
+                  <Row label="Cost">
+                    {status.total_cost > 0 ? `$${status.total_cost.toFixed(4)}` : "—"}
+                  </Row>
+                  {status.created_at && (
+                    <Row label="Created">{new Date(status.created_at).toLocaleString()}</Row>
+                  )}
+                  {status.busy_since && (
+                    <Row label="Busy since">{new Date(status.busy_since).toLocaleTimeString()}</Row>
+                  )}
+                  {status.working_dir && (
+                    <Row label="Working dir">
+                      <span className="session-info-mono session-info-truncate" title={status.working_dir}>
+                        {status.working_dir}
+                      </span>
+                    </Row>
+                  )}
+                  <Row label="Session ID">
+                    <span className="session-info-mono session-info-truncate">{sessionId.slice(0, 12)}</span>
+                    <button className="session-info-copy-btn" onClick={copySessionId} title="Copy full session ID">
+                      {copied ? "Copied!" : "Copy"}
+                    </button>
+                  </Row>
                 </div>
               ) : (
-                <span className="session-info-muted">None (default-deny)</span>
+                <div className="session-info-loading">Loading...</div>
               )}
-            </Row>
-            {agent.prompt && (
-              <Row label="Prompt">
-                <span className="session-info-muted session-info-truncate">
-                  {agent.prompt.length > 120
-                    ? agent.prompt.slice(0, 120) + "..."
-                    : agent.prompt}
-                </span>
-              </Row>
+            </section>
+
+            {/* Git worktree */}
+            {status?.worktree_group && (
+              <section className="session-info-section">
+                <h3 className="session-info-heading">Git Worktree</h3>
+                <div className="session-info-grid">
+                  <Row label="Mode">{status.worktree_group.single_repo ? "Single repo" : "Multi-repo"}</Row>
+                  {status.worktree_group.repos.map((repo, i) => (
+                    <Row key={i} label={`Branch ${i + 1}`}>
+                      <span className="session-info-mono">{repo.branch}</span>
+                    </Row>
+                  ))}
+                  <Row label="Shadow root">
+                    <span className="session-info-mono session-info-truncate" title={status.worktree_group.shadow_root}>
+                      {status.worktree_group.shadow_root}
+                    </span>
+                  </Row>
+                </div>
+              </section>
             )}
-            {agent.append_system_prompt && (
-              <Row label="System append">
-                <span className="session-info-muted session-info-truncate">
-                  {agent.append_system_prompt.length > 80
-                    ? agent.append_system_prompt.slice(0, 80) + "..."
-                    : agent.append_system_prompt}
-                </span>
-              </Row>
+
+            {/* Agent config */}
+            {agent && (
+              <section className="session-info-section">
+                <h3 className="session-info-heading">Agent</h3>
+                <div className="session-info-grid">
+                  <Row label="Name">
+                    {editingField === "name" ? (
+                      <input ref={editInputRef} className="session-info-inline-input" value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)} onKeyDown={handleEditKeyDown} onBlur={cancelEdit} />
+                    ) : (
+                      <>{agent.name} <button className="session-info-edit-btn" onClick={() => startEdit("name")} title="Edit name">✎</button></>
+                    )}
+                  </Row>
+                  <Row label="Working dir">
+                    {editingField === "working_dir" ? (
+                      <input ref={editInputRef} className="session-info-inline-input session-info-mono" value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)} onKeyDown={handleEditKeyDown} onBlur={cancelEdit} />
+                    ) : (
+                      <>
+                        <span className="session-info-mono session-info-truncate">{agent.working_dir || "—"}</span>
+                        <button className="session-info-edit-btn" onClick={() => startEdit("working_dir")} title="Edit working directory">✎</button>
+                      </>
+                    )}
+                  </Row>
+                  <Row label="Permissions">
+                    {editingPerms ? (
+                      <div className="session-info-perm-editor">
+                        <div className="session-info-perm-toggles">
+                          {KNOWN_PERMISSIONS.map((p) => (
+                            <button key={p}
+                              className={`session-info-perm-toggle ${draftPerms.includes(p) ? "session-info-perm-toggle-on" : ""}`}
+                              onClick={() => togglePerm(p)}>{p}</button>
+                          ))}
+                        </div>
+                        <div className="session-info-perm-actions">
+                          <button className="session-info-btn" onClick={savePerms}>Save</button>
+                          <button className="session-info-btn" onClick={() => setEditingPerms(false)}>Cancel</button>
+                        </div>
+                        <span className="session-info-muted">Changes take effect on next session</span>
+                      </div>
+                    ) : (
+                      <>
+                        {agent.permissions.length > 0 ? (
+                          <div className="session-info-tags">
+                            {agent.permissions.map((p) => (
+                              <span key={p} className="session-info-tag">{p}</span>
+                            ))}
+                          </div>
+                        ) : (
+                          <span className="session-info-muted">None (default-deny)</span>
+                        )}
+                        <button className="session-info-edit-btn" onClick={startPermEdit} title="Edit permissions">✎</button>
+                      </>
+                    )}
+                  </Row>
+                </div>
+              </section>
             )}
+
+            {/* Actions */}
+            <section className="session-info-section">
+              <h3 className="session-info-heading">Actions</h3>
+              <div className="session-info-actions">
+                <button className="session-info-btn session-info-btn-warning" onClick={handleKill}
+                  disabled={killing || !status?.process_alive}
+                  title={status?.process_alive ? "Force-kill the Claude process" : "No active process"}>
+                  {killing ? "Killing..." : "Kill Process"}
+                </button>
+                {!confirmDelete ? (
+                  <button className="session-info-btn session-info-btn-danger"
+                    onClick={() => setConfirmDelete(true)} disabled={deleting}>
+                    Delete Session
+                  </button>
+                ) : (
+                  <div className="session-info-confirm">
+                    <span className="session-info-confirm-text">Delete this session?</span>
+                    <button className="session-info-btn session-info-btn-danger"
+                      onClick={handleDelete} disabled={deleting}>
+                      {deleting ? "Deleting..." : "Confirm"}
+                    </button>
+                    <button className="session-info-btn" onClick={() => setConfirmDelete(false)}>Cancel</button>
+                  </div>
+                )}
+              </div>
+            </section>
+
+            {error && <div className="session-info-error">{error}</div>}
           </div>
-        </section>
-      )}
+        )}
 
-      {/* ── Actions ── */}
-      <section className="session-info-section">
-        <h3 className="session-info-heading">Actions</h3>
-        <div className="session-info-actions">
-          <button
-            className="session-info-btn session-info-btn-warning"
-            onClick={handleKill}
-            disabled={killing || !status?.process_alive}
-            title={status?.process_alive ? "Force-kill the Claude process" : "No active process"}
-          >
-            {killing ? "Killing..." : "Kill Process"}
-          </button>
-          {!confirmDelete ? (
-            <button
-              className="session-info-btn session-info-btn-danger"
-              onClick={() => setConfirmDelete(true)}
-              disabled={deleting}
-            >
-              Delete Session
-            </button>
-          ) : (
-            <div className="session-info-confirm">
-              <span className="session-info-confirm-text">Delete this session?</span>
-              <button
-                className="session-info-btn session-info-btn-danger"
-                onClick={handleDelete}
-                disabled={deleting}
-              >
-                {deleting ? "Deleting..." : "Confirm"}
-              </button>
-              <button
-                className="session-info-btn"
-                onClick={() => setConfirmDelete(false)}
-              >
-                Cancel
-              </button>
+        {/* Agent prompt (read-only) */}
+        {selected === "prompts/agent" && agent?.prompt && (
+          <>
+            <div className="fv-content-header">
+              <span className="fv-content-path">Agent Prompt</span>
             </div>
-          )}
-        </div>
-      </section>
+            <div className="fv-content-body">
+              <div className="fv-markdown">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{agent.prompt}</ReactMarkdown>
+              </div>
+            </div>
+          </>
+        )}
 
-      {error && <div className="session-info-error">{error}</div>}
+        {/* System prompt (read-only) */}
+        {selected === "prompts/system" && agent?.append_system_prompt && (
+          <>
+            <div className="fv-content-header">
+              <span className="fv-content-path">System Append Prompt</span>
+            </div>
+            <div className="fv-content-body">
+              <div className="fv-markdown">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{agent.append_system_prompt}</ReactMarkdown>
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* File-based views (skills, config) */}
+        {isFileView && (
+          <>
+            <div className="fv-content-header">
+              <span className="fv-content-path">{filePath}</span>
+            </div>
+            {fileLoading ? (
+              <div className="fv-content-empty">Loading...</div>
+            ) : fileContent !== null ? (
+              <div className="fv-content-body">
+                {isMarkdown ? (
+                  <div className="fv-markdown">
+                    <ReactMarkdown
+                      remarkPlugins={[remarkGfm]}
+                      components={{
+                        code({ className, children, ...props }) {
+                          const match = /language-(\w+)/.exec(className || "");
+                          const code = String(children).replace(/\n$/, "");
+                          if (match) {
+                            return (
+                              <div className="fv-md-code-block">
+                                <ShikiHighlighter language={match[1]} theme={theme}
+                                  addDefaultStyles={false} showLanguage={false}>
+                                  {code}
+                                </ShikiHighlighter>
+                              </div>
+                            );
+                          }
+                          return <code className={className} {...props}>{children}</code>;
+                        },
+                      }}
+                    >
+                      {fileContent}
+                    </ReactMarkdown>
+                  </div>
+                ) : (
+                  <div className="fv-shiki">
+                    <ShikiHighlighter
+                      language={langFromPath(filePath ?? "")}
+                      theme={theme}
+                      addDefaultStyles={false}
+                      showLanguage={false}
+                    >
+                      {fileContent}
+                    </ShikiHighlighter>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="fv-content-empty">Select a file to view</div>
+            )}
+          </>
+        )}
+      </div>
     </div>
   );
+}
+
+function langFromPath(path: string): string {
+  const EXT_TO_LANG: Record<string, string> = {
+    ts: "typescript", tsx: "tsx", js: "javascript", jsx: "jsx",
+    rs: "rust", py: "python", go: "go", json: "json",
+    yaml: "yaml", yml: "yaml", toml: "toml", md: "markdown",
+    html: "html", css: "css", sh: "bash", bash: "bash",
+  };
+  const name = path.split("/").pop() ?? "";
+  const ext = name.split(".").pop()?.toLowerCase() ?? "";
+  return EXT_TO_LANG[ext] ?? "text";
 }
 
 function Row({ label, children }: { label: string; children: React.ReactNode }) {
@@ -221,10 +665,5 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
 
 function StatusDot({ alive, busy }: { alive: boolean; busy: boolean }) {
   const color = busy ? "var(--warning)" : alive ? "var(--success)" : "var(--text-secondary)";
-  return (
-    <span
-      className="session-info-dot"
-      style={{ background: color }}
-    />
-  );
+  return <span className="session-info-dot" style={{ background: color }} />;
 }

--- a/cthulu-studio/src/components/SessionInfoPanel.tsx
+++ b/cthulu-studio/src/components/SessionInfoPanel.tsx
@@ -1,0 +1,230 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  getAgent,
+  getSessionStatus,
+  killSession,
+  deleteAgentSession,
+  type SessionStatus,
+} from "../api/client";
+import type { Agent } from "../types/flow";
+
+interface SessionInfoPanelProps {
+  agentId: string;
+  sessionId: string;
+  onSessionDeleted: () => void;
+}
+
+export default function SessionInfoPanel({
+  agentId,
+  sessionId,
+  onSessionDeleted,
+}: SessionInfoPanelProps) {
+  const [agent, setAgent] = useState<Agent | null>(null);
+  const [status, setStatus] = useState<SessionStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [killing, setKilling] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  // Fetch agent + session status on mount and periodically
+  useEffect(() => {
+    let cancelled = false;
+    const fetchAll = async () => {
+      try {
+        const [a, s] = await Promise.all([
+          getAgent(agentId),
+          getSessionStatus(agentId, sessionId),
+        ]);
+        if (cancelled) return;
+        setAgent(a);
+        setStatus(s);
+        setError(null);
+      } catch {
+        if (!cancelled) setError("Failed to load session info");
+      }
+    };
+    fetchAll();
+    const interval = setInterval(fetchAll, 5000);
+    return () => { cancelled = true; clearInterval(interval); };
+  }, [agentId, sessionId]);
+
+  const handleKill = useCallback(async () => {
+    setKilling(true);
+    try {
+      await killSession(agentId, sessionId);
+      const s = await getSessionStatus(agentId, sessionId);
+      setStatus(s);
+    } catch {
+      setError("Failed to kill session");
+    } finally {
+      setKilling(false);
+    }
+  }, [agentId, sessionId]);
+
+  const handleDelete = useCallback(async () => {
+    setDeleting(true);
+    try {
+      await deleteAgentSession(agentId, sessionId);
+      onSessionDeleted();
+    } catch {
+      setError("Failed to delete session");
+      setDeleting(false);
+      setConfirmDelete(false);
+    }
+  }, [agentId, sessionId, onSessionDeleted]);
+
+  if (error && !agent && !status) {
+    return (
+      <div className="session-info-panel">
+        <div className="session-info-error">{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="session-info-panel">
+      {/* ── Session Status ── */}
+      <section className="session-info-section">
+        <h3 className="session-info-heading">Session</h3>
+        {status ? (
+          <div className="session-info-grid">
+            <Row label="Status">
+              <StatusDot alive={status.process_alive} busy={status.busy} />
+              {status.busy
+                ? "Busy"
+                : status.process_alive
+                  ? "Idle"
+                  : "Stopped"}
+            </Row>
+            <Row label="Messages">{status.message_count}</Row>
+            <Row label="Cost">
+              {status.total_cost > 0
+                ? `$${status.total_cost.toFixed(4)}`
+                : "—"}
+            </Row>
+            {status.busy_since && (
+              <Row label="Busy since">
+                {new Date(status.busy_since).toLocaleTimeString()}
+              </Row>
+            )}
+            <Row label="Session ID">
+              <span className="session-info-mono session-info-truncate">
+                {sessionId.slice(0, 12)}
+              </span>
+            </Row>
+          </div>
+        ) : (
+          <div className="session-info-loading">Loading...</div>
+        )}
+      </section>
+
+      {/* ── Agent Config ── */}
+      {agent && (
+        <section className="session-info-section">
+          <h3 className="session-info-heading">Agent</h3>
+          <div className="session-info-grid">
+            <Row label="Name">{agent.name}</Row>
+            {agent.working_dir && (
+              <Row label="Working dir">
+                <span className="session-info-mono session-info-truncate">
+                  {agent.working_dir}
+                </span>
+              </Row>
+            )}
+            <Row label="Permissions">
+              {agent.permissions.length > 0 ? (
+                <div className="session-info-tags">
+                  {agent.permissions.map((p) => (
+                    <span key={p} className="session-info-tag">{p}</span>
+                  ))}
+                </div>
+              ) : (
+                <span className="session-info-muted">None (default-deny)</span>
+              )}
+            </Row>
+            {agent.prompt && (
+              <Row label="Prompt">
+                <span className="session-info-muted session-info-truncate">
+                  {agent.prompt.length > 120
+                    ? agent.prompt.slice(0, 120) + "..."
+                    : agent.prompt}
+                </span>
+              </Row>
+            )}
+            {agent.append_system_prompt && (
+              <Row label="System append">
+                <span className="session-info-muted session-info-truncate">
+                  {agent.append_system_prompt.length > 80
+                    ? agent.append_system_prompt.slice(0, 80) + "..."
+                    : agent.append_system_prompt}
+                </span>
+              </Row>
+            )}
+          </div>
+        </section>
+      )}
+
+      {/* ── Actions ── */}
+      <section className="session-info-section">
+        <h3 className="session-info-heading">Actions</h3>
+        <div className="session-info-actions">
+          <button
+            className="session-info-btn session-info-btn-warning"
+            onClick={handleKill}
+            disabled={killing || !status?.process_alive}
+            title={status?.process_alive ? "Force-kill the Claude process" : "No active process"}
+          >
+            {killing ? "Killing..." : "Kill Process"}
+          </button>
+          {!confirmDelete ? (
+            <button
+              className="session-info-btn session-info-btn-danger"
+              onClick={() => setConfirmDelete(true)}
+              disabled={deleting}
+            >
+              Delete Session
+            </button>
+          ) : (
+            <div className="session-info-confirm">
+              <span className="session-info-confirm-text">Delete this session?</span>
+              <button
+                className="session-info-btn session-info-btn-danger"
+                onClick={handleDelete}
+                disabled={deleting}
+              >
+                {deleting ? "Deleting..." : "Confirm"}
+              </button>
+              <button
+                className="session-info-btn"
+                onClick={() => setConfirmDelete(false)}
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {error && <div className="session-info-error">{error}</div>}
+    </div>
+  );
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="session-info-row">
+      <span className="session-info-label">{label}</span>
+      <span className="session-info-value">{children}</span>
+    </div>
+  );
+}
+
+function StatusDot({ alive, busy }: { alive: boolean; busy: boolean }) {
+  const color = busy ? "var(--warning)" : alive ? "var(--success)" : "var(--text-secondary)";
+  return (
+    <span
+      className="session-info-dot"
+      style={{ background: color }}
+    />
+  );
+}

--- a/cthulu-studio/src/styles.css
+++ b/cthulu-studio/src/styles.css
@@ -942,6 +942,7 @@ button:disabled {
   flex-shrink: 0;
 }
 .ref-toolbar-btn {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -5125,6 +5126,14 @@ button:disabled {
   padding: 12px;
   gap: 16px;
 }
+.session-info-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 12px;
+  overflow-y: auto;
+  height: 100%;
+}
 .session-info-section {
   display: flex;
   flex-direction: column;
@@ -5255,4 +5264,153 @@ button:disabled {
 .session-info-loading {
   font-size: 11px;
   color: var(--text-secondary);
+}
+
+/* Copy button */
+.session-info-copy-btn {
+  font-size: 9px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+.session-info-copy-btn:hover {
+  background: var(--bg-tertiary, var(--bg-secondary));
+  color: var(--text);
+}
+
+/* Inline edit input */
+.session-info-inline-input {
+  font-size: 11px;
+  padding: 1px 4px;
+  border: 1px solid var(--accent);
+  border-radius: 3px;
+  background: var(--bg);
+  color: var(--text);
+  outline: none;
+  min-width: 80px;
+  max-width: 180px;
+}
+
+/* Pencil edit button */
+.session-info-edit-btn {
+  font-size: 10px;
+  padding: 0 3px;
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  opacity: 0.5;
+  transition: opacity 0.1s;
+}
+.session-info-edit-btn:hover {
+  opacity: 1;
+  color: var(--accent);
+}
+
+/* Permission toggle editor */
+.session-info-perm-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.session-info-perm-toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.session-info-perm-toggle {
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s, color 0.1s;
+}
+.session-info-perm-toggle:hover {
+  border-color: var(--accent);
+}
+.session-info-perm-toggle-on {
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.session-info-perm-actions {
+  display: flex;
+  gap: 6px;
+}
+
+/* Clickable heading toggle */
+.session-info-heading-toggle {
+  cursor: pointer;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.session-info-heading-toggle:hover {
+  color: var(--text);
+}
+
+/* Hooks badge */
+.session-info-hooks-badge {
+  font-size: 9px;
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--accent);
+}
+
+/* Git repo block */
+.session-info-git-repo {
+  padding: 4px 0 4px 8px;
+  border-left: 2px solid var(--border);
+  margin-top: 4px;
+}
+
+/* Prompt display blocks */
+.session-info-prompt-block {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.session-info-prompt-pre {
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  font-size: 10px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 6px 8px;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+/* Toolbar badge */
+.ref-toolbar-badge {
+  position: absolute;
+  top: -2px;
+  right: -4px;
+  font-size: 8px;
+  min-width: 14px;
+  height: 14px;
+  border-radius: 7px;
+  background: var(--accent);
+  color: var(--bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 3px;
+  font-weight: 600;
+  line-height: 1;
 }

--- a/cthulu-studio/src/styles.css
+++ b/cthulu-studio/src/styles.css
@@ -5115,3 +5115,144 @@ button:disabled {
   user-select: none;
   opacity: 0.6;
 }
+
+/* ── Session Info Panel ── */
+.session-info-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+  padding: 12px;
+  gap: 16px;
+}
+.session-info-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.session-info-heading {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+  margin: 0;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--border);
+}
+.session-info-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.session-info-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 11px;
+  line-height: 1.5;
+}
+.session-info-label {
+  color: var(--text-secondary);
+  min-width: 90px;
+  flex-shrink: 0;
+}
+.session-info-value {
+  color: var(--text);
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.session-info-mono {
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  font-size: 10px;
+}
+.session-info-truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+  display: inline-block;
+}
+.session-info-muted {
+  color: var(--text-secondary);
+  font-size: 10px;
+}
+.session-info-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.session-info-tag {
+  font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  color: var(--accent);
+}
+.session-info-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.session-info-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.session-info-btn {
+  font-size: 11px;
+  padding: 5px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+}
+.session-info-btn:hover:not(:disabled) {
+  background: var(--bg-tertiary, var(--bg-secondary));
+  border-color: var(--text-secondary);
+}
+.session-info-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.session-info-btn-warning {
+  border-color: var(--warning);
+  color: var(--warning);
+}
+.session-info-btn-warning:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--warning) 10%, transparent);
+}
+.session-info-btn-danger {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+.session-info-btn-danger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
+}
+.session-info-confirm {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.session-info-confirm-text {
+  font-size: 11px;
+  color: var(--danger);
+}
+.session-info-error {
+  font-size: 11px;
+  color: var(--danger);
+  padding: 4px 0;
+}
+.session-info-loading {
+  font-size: 11px;
+  color: var(--text-secondary);
+}


### PR DESCRIPTION
## Summary
- Adds a **Session Info** tab (ℹ icon) to the agent detail right-pane toolbar
- Shows agent config (permissions, working dir, prompt), session stats (status, messages, cost), and session controls (kill process, delete session)
- Fixes the "no way to terminate a session" problem

## What's in the panel

### Session section
- Live status indicator (green=idle, yellow=busy, gray=stopped) with auto-refresh every 5s
- Message count, cumulative cost, busy-since timestamp
- Truncated session ID

### Agent section
- Agent name, working directory
- Permissions displayed as accent-colored tags (or "None (default-deny)")
- Prompt and system append previews (truncated)

### Actions section
- **Kill Process** — force-kills the Claude process (disabled when no process is alive)
- **Delete Session** — with confirmation step, triggers cleanup in the parent

## Files changed
- `SessionInfoPanel.tsx` (new) — the panel component
- `AgentDetailView.tsx` — add "info" tab to ReferenceTab type and toolbar
- `styles.css` — add `.session-info-*` styles

## Test plan
- [ ] Open an agent, click the ℹ icon in the right toolbar
- [ ] Verify session status shows correctly (idle/busy/stopped)
- [ ] Verify agent permissions display as tags
- [ ] Send a message, watch status update to "Busy" then back to "Idle"
- [ ] Click "Kill Process" while agent is busy — verify process stops
- [ ] Click "Delete Session" → confirm → verify session is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)