### PR TITLE
feat: auth dependencies + config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,13 @@ logs/
 .nx/
 node_modules/
 .claude/
+
+# Memory files (Claude auto-memory, not tracked)
+MEMORY.md
+
+# Superpowers (local brainstorm/dev artifacts)
+.superpowers/
+
+# Docs: plans, specs, and setup guides (separate from feature code)
+docs/superpowers/
+docs/better-auth-setup.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,6 +367,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bcrypt"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523ab528ce3a7ada6597f8ccf5bd8d85ebe26d5edf311cad4d1d3cfb2d357ac6"
+dependencies = [
+ "base64",
+ "blowfish",
+ "getrandom 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +407,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -457,6 +480,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -619,6 +652,8 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "base64",
+ "bcrypt",
  "chrono",
  "clap",
  "claude-agent-sdk-rust",
@@ -629,6 +664,7 @@ dependencies = [
  "futures",
  "gcp_auth",
  "hyper",
+ "jsonwebtoken",
  "notify",
  "notify-debouncer-mini",
  "reqwest",
@@ -1509,6 +1545,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1598,21 @@ checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -1828,10 +1888,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2124,6 +2203,16 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -3021,6 +3110,18 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ futures = "0.3.32"
 async-stream = "0.3.6"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+jsonwebtoken = "9"
+base64 = "0.22"
+bcrypt = "0.19"
 serde_yaml = "0.9.34"
 async-trait = "0.1.89"
 hyper = { version = "1", default-features = false, features = ["http1", "http2", "server", "client"] }

--- a/cthulu-backend/config.rs
+++ b/cthulu-backend/config.rs
@@ -5,6 +5,7 @@ pub struct Config {
     pub port: u16,
     pub sentry_dsn: Option<String>,
     pub environment: String,
+    pub auth_enabled: bool,
 }
 
 impl Config {
@@ -13,6 +14,7 @@ impl Config {
             std::env::var("PORT").ok().as_deref(),
             std::env::var("SENTRY_DSN").ok().as_deref(),
             std::env::var("ENVIRONMENT").ok().as_deref(),
+            std::env::var("AUTH_ENABLED").ok().as_deref(),
         )
     }
 
@@ -22,6 +24,7 @@ impl Config {
         port: Option<&str>,
         sentry_dsn: Option<&str>,
         environment: Option<&str>,
+        auth_enabled: Option<&str>,
     ) -> Self {
         let port = port.and_then(|v| v.parse().ok()).unwrap_or(8081);
 
@@ -32,10 +35,13 @@ impl Config {
             .map(String::from)
             .unwrap_or_else(|| "local".to_string());
 
+        let auth_enabled = auth_enabled.map(|v| v == "true").unwrap_or(false);
+
         Config {
             port,
             sentry_dsn,
             environment,
+            auth_enabled,
         }
     }
 }
@@ -119,37 +125,49 @@ mod tests {
 
     #[test]
     fn test_config_invalid_port_uses_default() {
-        let config = Config::from_raw_values(Some("not-a-number"), None, None);
+        let config = Config::from_raw_values(Some("not-a-number"), None, None, None);
         assert_eq!(config.port, 8081);
     }
 
     #[test]
     fn test_config_valid_port() {
-        let config = Config::from_raw_values(Some("3000"), None, None);
+        let config = Config::from_raw_values(Some("3000"), None, None, None);
         assert_eq!(config.port, 3000);
     }
 
     #[test]
     fn test_config_empty_sentry_dsn_is_none() {
-        let config = Config::from_raw_values(None, Some(""), None);
+        let config = Config::from_raw_values(None, Some(""), None, None);
         assert!(config.sentry_dsn.is_none());
     }
 
     #[test]
     fn test_config_present_sentry_dsn() {
-        let config = Config::from_raw_values(None, Some("https://sentry.io/123"), None);
+        let config = Config::from_raw_values(None, Some("https://sentry.io/123"), None, None);
         assert_eq!(config.sentry_dsn.as_deref(), Some("https://sentry.io/123"));
     }
 
     #[test]
     fn test_config_default_environment() {
-        let config = Config::from_raw_values(None, None, None);
+        let config = Config::from_raw_values(None, None, None, None);
         assert_eq!(config.environment, "local");
     }
 
     #[test]
     fn test_config_custom_environment() {
-        let config = Config::from_raw_values(None, None, Some("production"));
+        let config = Config::from_raw_values(None, None, Some("production"), None);
         assert_eq!(config.environment, "production");
+    }
+
+    #[test]
+    fn test_config_auth_enabled_true() {
+        let config = Config::from_raw_values(None, None, None, Some("true"));
+        assert!(config.auth_enabled);
+    }
+
+    #[test]
+    fn test_config_auth_enabled_default_false() {
+        let config = Config::from_raw_values(None, None, None, None);
+        assert!(!config.auth_enabled);
     }
 }


### PR DESCRIPTION
## Summary

- Add `jsonwebtoken`, `base64`, `bcrypt` to Cargo.toml for JWT-based auth
- Add `auth_enabled` config field (`AUTH_ENABLED` env var, default `false`)
- Update `.gitignore` to exclude memory files, superpowers, and doc artifacts

## Files changed (4 files, ~40 lines of feature code)
- `Cargo.toml` — 3 new deps
- `Cargo.lock` — lockfile update
- `config.rs` — `auth_enabled` field + 2 tests
- `.gitignore` — exclude docs/memory/brainstorm artifacts

## Verification
- `cargo check` — 0 errors
- `cargo test config` — all pass

## Dependency chain
**This is PR A (1/6)** — base for all auth/teams work.

```
main
 └─ PR A (this) ← deps + config
     └─ PR B ← auth module
         ├─ PR C ← frontend auth gate
         └─ PR D ← teams backend
              └─ PR E ← profile + teams UI
                   └─ PR F ← team sessions
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)