### PR TITLE
feat: team sessions — shared agents with multi-user broadcast

### DIFF
--- a/cthulu-backend/agents/mod.rs
+++ b/cthulu-backend/agents/mod.rs
@@ -96,6 +96,9 @@ pub struct Agent {
     /// If true, this agent is only usable as a sub-agent and is hidden from the UI agent list.
     #[serde(default)]
     pub subagent_only: bool,
+    /// When set, this agent belongs to a team. All team members can access it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team_id: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -214,6 +217,7 @@ impl AgentBuilder<Ready> {
             hooks: self.hooks,
             subagents: self.subagents,
             subagent_only: self.subagent_only,
+            team_id: None,
             created_at: now,
             updated_at: now,
         }

--- a/cthulu-backend/api/agents/chat.rs
+++ b/cthulu-backend/api/agents/chat.rs
@@ -781,6 +781,7 @@ fn chat_sdk_stream(
 
 /// POST /agents/{id}/chat — SSE stream for agent chat
 pub(crate) async fn chat(
+    auth: crate::api::local_auth::AuthUser,
     State(state): State<AppState>,
     Path(id): Path<String>,
     Json(body): Json<ChatRequest>,
@@ -792,6 +793,15 @@ pub(crate) async fn chat(
         (StatusCode::NOT_FOUND, Json(json!({ "error": "agent not found" })))
     })?;
 
+    // If team agent, verify sender is a team member
+    if let Some(ref team_id) = agent.team_id {
+        let ts = state.team_store.read().await;
+        if !ts.teams.get(team_id).map(|t| t.members.contains(&auth.user_id)).unwrap_or(false) {
+            return Err((StatusCode::FORBIDDEN, Json(json!({ "error": "Not a member of this team" }))));
+        }
+    }
+
+    let sender_user_id = auth.user_id.clone();
     let prompt = body.prompt;
     let images = body.images.unwrap_or_default();
     if prompt.trim().is_empty() && images.is_empty() {
@@ -1208,6 +1218,8 @@ pub(crate) async fn chat(
     let live_processes = state.live_processes.clone();
     let session_streams = state.session_streams.clone();
     let chat_event_buffers = state.chat_event_buffers.clone();
+    let sender_id_for_bc = sender_user_id.clone();
+    let prompt_for_bc = prompt.chars().take(200).collect::<String>();
 
     let stream = async_stream::stream! {
         use std::process::Stdio;
@@ -1438,6 +1450,16 @@ pub(crate) async fn chat(
                 proc_key = %proc_key_for_stream,
                 "[RECONNECT-DEBUG] Created event buffer"
             );
+        }
+
+        // Broadcast sender attribution for team session spectators
+        {
+            let evt = format!("user_message:{}", serde_json::to_string(&json!({
+                "user_id": sender_id_for_bc, "text": prompt_for_bc,
+            })).unwrap_or_default());
+            let _ = bc_tx.send(evt.clone());
+            let mut bufs = chat_event_buffers.lock().await;
+            if let Some(b) = bufs.get_mut(&proc_key_for_stream) { b.push(evt); }
         }
 
         // Spawn the background reader task

--- a/cthulu-backend/api/local_auth.rs
+++ b/cthulu-backend/api/local_auth.rs
@@ -7,7 +7,7 @@
 //! and all requests get a hardcoded "dev_user" identity.
 
 use axum::extract::FromRequestParts;
-use axum::routing::post;
+use axum::routing::{get, post, put};
 use axum::{Json, Router};
 use hyper::header::AUTHORIZATION;
 use hyper::http::request::Parts;
@@ -260,6 +260,8 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/auth/signup", post(signup))
         .route("/auth/login", post(login))
+        .route("/auth/me", get(get_profile).put(update_profile))
+        .route("/auth/users/search", get(search_users))
 }
 
 async fn signup(
@@ -387,6 +389,83 @@ async fn login(
             "user": { "id": user.id, "email": user.email }
         })),
     )
+}
+
+// ── Profile Handlers ─────────────────────────────────────────
+
+async fn get_profile(
+    auth: AuthUser,
+    axum::extract::State(state): axum::extract::State<AppState>,
+) -> (StatusCode, Json<Value>) {
+    let store = state.user_store.read().await;
+    let user = store.users.values().find(|u| u.id == auth.user_id);
+    match user {
+        Some(u) => (StatusCode::OK, Json(json!({
+            "id": u.id, "email": u.email, "name": u.name,
+            "avatar_url": u.avatar_url, "created_at": u.created_at,
+        }))),
+        None => (StatusCode::NOT_FOUND, Json(json!({ "error": "User not found" }))),
+    }
+}
+
+#[derive(Deserialize)]
+struct UpdateProfileRequest {
+    name: Option<String>,
+    avatar_url: Option<String>,
+}
+
+async fn update_profile(
+    auth: AuthUser,
+    axum::extract::State(state): axum::extract::State<AppState>,
+    Json(body): Json<UpdateProfileRequest>,
+) -> (StatusCode, Json<Value>) {
+    let mut store = state.user_store.write().await;
+    let email_key = store.users.iter()
+        .find(|(_, u)| u.id == auth.user_id)
+        .map(|(email, _)| email.clone());
+
+    let Some(email) = email_key else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "error": "User not found" })));
+    };
+    let Some(user) = store.users.get_mut(&email) else {
+        return (StatusCode::NOT_FOUND, Json(json!({ "error": "User not found" })));
+    };
+    if let Some(name) = body.name {
+        user.name = Some(name);
+    }
+    if let Some(avatar_url) = body.avatar_url {
+        user.avatar_url = Some(avatar_url);
+    }
+    let updated = user.clone();
+    let _ = store.save(&state.data_dir);
+
+    (StatusCode::OK, Json(json!({
+        "id": updated.id, "email": updated.email,
+        "name": updated.name, "avatar_url": updated.avatar_url,
+    })))
+}
+
+async fn search_users(
+    _auth: AuthUser,
+    axum::extract::State(state): axum::extract::State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> (StatusCode, Json<Value>) {
+    let query = params.get("q").map(|s| s.trim().to_lowercase()).unwrap_or_default();
+    if query.is_empty() {
+        return (StatusCode::OK, Json(json!({ "users": [] })));
+    }
+
+    let store = state.user_store.read().await;
+    let results: Vec<Value> = store.users.values()
+        .filter(|u| {
+            u.email.to_lowercase().contains(&query)
+                || u.name.as_ref().map(|n| n.to_lowercase().contains(&query)).unwrap_or(false)
+        })
+        .take(10)
+        .map(|u| json!({ "id": u.id, "email": u.email, "name": u.name }))
+        .collect();
+
+    (StatusCode::OK, Json(json!({ "users": results })))
 }
 
 // ── Tests ────────────────────────────────────────────────────

--- a/cthulu-backend/api/mod.rs
+++ b/cthulu-backend/api/mod.rs
@@ -10,6 +10,7 @@ pub mod middleware;
 pub mod prompts;
 mod routes;
 pub mod scheduler;
+pub mod teams;
 pub mod templates;
 pub mod user_context;
 
@@ -340,6 +341,8 @@ pub struct AppState {
     pub jwt_secret: Arc<String>,
     /// In-memory user store (email/password accounts).
     pub user_store: Arc<RwLock<local_auth::UserStore>>,
+    /// In-memory team store.
+    pub team_store: Arc<RwLock<teams::TeamStore>>,
 }
 
 impl AppState {

--- a/cthulu-backend/api/routes.rs
+++ b/cthulu-backend/api/routes.rs
@@ -58,6 +58,7 @@ fn api_router() -> Router<AppState> {
         .merge(super::hooks::router())
         .merge(super::dashboard::router())
         .merge(super::local_auth::router())
+        .merge(super::teams::router())
 }
 
 async fn not_found(req: axum::extract::Request) -> impl IntoResponse {

--- a/cthulu-backend/api/teams.rs
+++ b/cthulu-backend/api/teams.rs
@@ -1,0 +1,240 @@
+//! Teams: flat groups of users. No roles — all members are equal.
+//! Stored in `{data_dir}/teams.json`.
+
+use axum::extract::{Path, State};
+use axum::routing::{delete, get, post};
+use axum::{Json, Router};
+use hyper::StatusCode;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use crate::api::local_auth::AuthUser;
+use crate::api::AppState;
+
+// ── Team Model ───────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Team {
+    pub id: String,
+    pub name: String,
+    pub created_by: String,
+    pub members: Vec<String>,
+    pub created_at: String,
+}
+
+/// In-memory team store backed by `{data_dir}/teams.json`.
+pub struct TeamStore {
+    pub teams: HashMap<String, Team>,
+}
+
+impl TeamStore {
+    pub fn load(data_dir: &PathBuf) -> Self {
+        let path = data_dir.join("teams.json");
+        let teams = match std::fs::read_to_string(&path) {
+            Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
+            Err(_) => HashMap::new(),
+        };
+        Self { teams }
+    }
+
+    pub fn save(&self, data_dir: &PathBuf) -> std::io::Result<()> {
+        let path = data_dir.join("teams.json");
+        let json = serde_json::to_string_pretty(&self.teams)?;
+        std::fs::write(path, json)
+    }
+
+    pub fn teams_for_user(&self, user_id: &str) -> Vec<&Team> {
+        self.teams.values()
+            .filter(|t| t.members.contains(&user_id.to_string()))
+            .collect()
+    }
+}
+
+// ── Routes ───────────────────────────────────────────────────
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/teams", get(list_teams).post(create_team))
+        .route("/teams/{id}", get(get_team))
+        .route("/teams/{id}/members", post(add_member))
+        .route("/teams/{id}/members/{user_id}", delete(remove_member))
+}
+
+// ── Handlers ─────────────────────────────────────────────────
+
+async fn list_teams(
+    auth: AuthUser,
+    State(state): State<AppState>,
+) -> (StatusCode, Json<Value>) {
+    let store = state.team_store.read().await;
+    let teams: Vec<&Team> = store.teams_for_user(&auth.user_id);
+    (StatusCode::OK, Json(json!({ "teams": teams })))
+}
+
+#[derive(Deserialize)]
+struct CreateTeamRequest {
+    name: String,
+}
+
+async fn create_team(
+    auth: AuthUser,
+    State(state): State<AppState>,
+    Json(body): Json<CreateTeamRequest>,
+) -> (StatusCode, Json<Value>) {
+    let name = body.name.trim().to_string();
+    if name.is_empty() {
+        return (StatusCode::BAD_REQUEST, Json(json!({ "error": "Team name required" })));
+    }
+
+    let team = Team {
+        id: uuid::Uuid::new_v4().to_string().replace('-', "_"),
+        name,
+        created_by: auth.user_id.clone(),
+        members: vec![auth.user_id.clone()],
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+
+    let mut store = state.team_store.write().await;
+    let response = json!({ "team": &team });
+    store.teams.insert(team.id.clone(), team);
+    let _ = store.save(&state.data_dir);
+
+    (StatusCode::CREATED, Json(response))
+}
+
+async fn get_team(
+    auth: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> (StatusCode, Json<Value>) {
+    let store = state.team_store.read().await;
+    match store.teams.get(&id) {
+        Some(team) if team.members.contains(&auth.user_id) => {
+            let user_store = state.user_store.read().await;
+            let members: Vec<Value> = team.members.iter().map(|uid| {
+                let user = user_store.users.values().find(|u| u.id == *uid);
+                json!({
+                    "id": uid,
+                    "email": user.map(|u| u.email.as_str()).unwrap_or("unknown"),
+                    "name": user.and_then(|u| u.name.as_deref()),
+                })
+            }).collect();
+
+            (StatusCode::OK, Json(json!({
+                "team": {
+                    "id": team.id,
+                    "name": team.name,
+                    "created_by": team.created_by,
+                    "members": members,
+                    "created_at": team.created_at,
+                }
+            })))
+        }
+        Some(_) => (StatusCode::FORBIDDEN, Json(json!({ "error": "Not a member of this team" }))),
+        None => (StatusCode::NOT_FOUND, Json(json!({ "error": "Team not found" }))),
+    }
+}
+
+#[derive(Deserialize)]
+struct AddMemberRequest {
+    email: String,
+}
+
+async fn add_member(
+    auth: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<AddMemberRequest>,
+) -> (StatusCode, Json<Value>) {
+    let email = body.email.trim().to_lowercase();
+
+    let user_store = state.user_store.read().await;
+    let target_user = user_store.find_by_email(&email);
+    let target_id = match target_user {
+        Some(u) => u.id.clone(),
+        None => return (StatusCode::NOT_FOUND, Json(json!({ "error": "User not found" }))),
+    };
+    drop(user_store);
+
+    let mut store = state.team_store.write().await;
+    match store.teams.get_mut(&id) {
+        Some(team) if team.members.contains(&auth.user_id) => {
+            if team.members.contains(&target_id) {
+                return (StatusCode::CONFLICT, Json(json!({ "error": "Already a member" })));
+            }
+            team.members.push(target_id);
+            let _ = store.save(&state.data_dir);
+            (StatusCode::OK, Json(json!({ "ok": true })))
+        }
+        Some(_) => (StatusCode::FORBIDDEN, Json(json!({ "error": "Not a member of this team" }))),
+        None => (StatusCode::NOT_FOUND, Json(json!({ "error": "Team not found" }))),
+    }
+}
+
+async fn remove_member(
+    auth: AuthUser,
+    State(state): State<AppState>,
+    Path((id, user_id)): Path<(String, String)>,
+) -> (StatusCode, Json<Value>) {
+    let mut store = state.team_store.write().await;
+    match store.teams.get_mut(&id) {
+        Some(team) if team.members.contains(&auth.user_id) => {
+            team.members.retain(|m| m != &user_id);
+            if team.members.is_empty() {
+                store.teams.remove(&id);
+            }
+            let _ = store.save(&state.data_dir);
+            (StatusCode::OK, Json(json!({ "ok": true })))
+        }
+        Some(_) => (StatusCode::FORBIDDEN, Json(json!({ "error": "Not a member of this team" }))),
+        None => (StatusCode::NOT_FOUND, Json(json!({ "error": "Team not found" }))),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn team_store_roundtrip() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path().to_path_buf();
+
+        let mut store = TeamStore { teams: HashMap::new() };
+        store.teams.insert("t1".into(), Team {
+            id: "t1".into(),
+            name: "Alpha".into(),
+            created_by: "u1".into(),
+            members: vec!["u1".into(), "u2".into()],
+            created_at: "2026-01-01".into(),
+        });
+        store.save(&dir).unwrap();
+
+        let loaded = TeamStore::load(&dir);
+        assert_eq!(loaded.teams.len(), 1);
+        assert_eq!(loaded.teams["t1"].name, "Alpha");
+        assert_eq!(loaded.teams["t1"].members.len(), 2);
+    }
+
+    #[test]
+    fn teams_for_user_filters_correctly() {
+        let mut store = TeamStore { teams: HashMap::new() };
+        store.teams.insert("t1".into(), Team {
+            id: "t1".into(), name: "A".into(), created_by: "u1".into(),
+            members: vec!["u1".into(), "u2".into()], created_at: "".into(),
+        });
+        store.teams.insert("t2".into(), Team {
+            id: "t2".into(), name: "B".into(), created_by: "u3".into(),
+            members: vec!["u3".into()], created_at: "".into(),
+        });
+
+        assert_eq!(store.teams_for_user("u1").len(), 1);
+        assert_eq!(store.teams_for_user("u2").len(), 1);
+        assert_eq!(store.teams_for_user("u3").len(), 1);
+        assert_eq!(store.teams_for_user("u99").len(), 0);
+    }
+}

--- a/cthulu-backend/main.rs
+++ b/cthulu-backend/main.rs
@@ -374,6 +374,9 @@ async fn run_server(start_disabled: bool) -> Result<(), Box<dyn Error>> {
         user_store: Arc::new(tokio::sync::RwLock::new(
             crate::api::local_auth::UserStore::load(&base_dir),
         )),
+        team_store: Arc::new(tokio::sync::RwLock::new(
+            crate::api::teams::TeamStore::load(&base_dir),
+        )),
     };
 
     // Start file change watcher (keeps caches in sync with external edits)

--- a/cthulu-studio/src/App.tsx
+++ b/cthulu-studio/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import AuthGate from "./components/AuthGate";
 import * as api from "./api/client";
 import { log } from "./api/logger";
 import { subscribeToRuns } from "./api/runStream";
@@ -318,6 +319,7 @@ export default function App() {
   };
 
   return (
+    <AuthGate>
     <div className="app">
       <TopBar
         activeView={activeView}
@@ -457,5 +459,6 @@ export default function App() {
         </DialogContent>
       </Dialog>
     </div>
+    </AuthGate>
   );
 }

--- a/cthulu-studio/src/api/client.ts
+++ b/cthulu-studio/src/api/client.ts
@@ -37,6 +37,39 @@ export function getServerUrl(): string {
   return getBaseUrl();
 }
 
+// ── Auth token injection ─────────────────────────────────────
+
+let getTokenFn: (() => Promise<string | null>) | null = null;
+
+/** Called by AuthGate to wire token getter into all API requests. */
+export function setAuthTokenGetter(fn: (() => Promise<string | null>) | null) {
+  getTokenFn = fn;
+}
+
+/** Get the current auth token (if available). Used by SSE EventSource callers. */
+export async function getAuthToken(): Promise<string | null> {
+  return getTokenFn ? getTokenFn() : null;
+}
+
+/** Get auth token synchronously from localStorage (for EventSource URLs). */
+export function getAuthTokenSync(): string | null {
+  return localStorage.getItem("cthulu_auth_token");
+}
+
+/** Append ?token= to a URL for EventSource connections (which can't set headers). */
+export function withAuthToken(url: string): string {
+  const token = getAuthTokenSync();
+  if (!token) return url;
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}token=${encodeURIComponent(token)}`;
+}
+
+/** Get auth headers for fetch-based streaming (non-apiFetch callers). */
+export async function getAuthHeaders(): Promise<Record<string, string>> {
+  const token = await getAuthToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 async function apiFetch<T>(
   path: string,
   options: RequestInit = {}
@@ -47,11 +80,21 @@ async function apiFetch<T>(
   log("http", `${method} ${path}`);
   const start = performance.now();
 
+  // Attach auth token if available
+  const authHeaders: Record<string, string> = {};
+  if (getTokenFn) {
+    const token = await getTokenFn();
+    if (token) {
+      authHeaders["Authorization"] = `Bearer ${token}`;
+    }
+  }
+
   try {
     const res = await fetch(url, {
       ...options,
       headers: {
         "Content-Type": "application/json",
+        ...authHeaders,
         ...options.headers,
       },
     });
@@ -59,6 +102,11 @@ async function apiFetch<T>(
     const elapsed = Math.round(performance.now() - start);
 
     if (!res.ok) {
+      // Auto-logout on 401 (expired/invalid token)
+      if (res.status === 401 && getTokenFn) {
+        localStorage.removeItem("cthulu_auth_token");
+        window.location.reload();
+      }
       const body = await res.text();
       log("error", `${method} ${path} -> ${res.status} (${elapsed}ms)`, body);
       throw new Error(`API error ${res.status}: ${body}`);
@@ -326,7 +374,7 @@ export function streamSessionLog(
   onLine: (line: string) => void,
   onDone: () => void
 ): () => void {
-  const url = `${getBaseUrl()}/api/agents/${agentId}/sessions/${sessionId}/stream`;
+  const url = withAuthToken(`${getBaseUrl()}/api/agents/${agentId}/sessions/${sessionId}/stream`);
   const source = new EventSource(url);
 
   source.addEventListener("line", (e: MessageEvent) => {
@@ -540,6 +588,7 @@ export async function createAgent(data: {
   permissions?: string[];
   append_system_prompt?: string | null;
   working_dir?: string | null;
+  team_id?: string | null;
 }): Promise<{ id: string }> {
   return apiFetch<{ id: string }>("/agents", {
     method: "POST",
@@ -586,7 +635,7 @@ export interface ResourceChangeEvent {
 export function subscribeToChanges(
   onEvent: (event: ResourceChangeEvent) => void
 ): () => void {
-  const url = `${getBaseUrl()}/api/changes`;
+  const url = withAuthToken(`${getBaseUrl()}/api/changes`);
   const source = new EventSource(url);
 
   const handler = (e: MessageEvent) => {
@@ -706,4 +755,68 @@ export async function getDashboardSummary(
     method: "POST",
     body: JSON.stringify({ channels }),
   });
+}
+
+// ── Profile ──────────────────────────────────────────────────
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  name: string | null;
+  avatar_url: string | null;
+  created_at: string;
+}
+
+export async function getProfile(): Promise<UserProfile> {
+  return apiFetch<UserProfile>("/auth/me");
+}
+
+export async function updateProfile(data: { name?: string; avatar_url?: string }): Promise<UserProfile> {
+  return apiFetch<UserProfile>("/auth/me", { method: "PUT", body: JSON.stringify(data) });
+}
+
+export interface UserSearchResult {
+  id: string;
+  email: string;
+  name: string | null;
+}
+
+export async function searchUsers(query: string): Promise<{ users: UserSearchResult[] }> {
+  return apiFetch<{ users: UserSearchResult[] }>(`/auth/users/search?q=${encodeURIComponent(query)}`);
+}
+
+// ── Teams ────────────────────────────────────────────────────
+
+export interface TeamMember {
+  id: string;
+  email: string;
+  name: string | null;
+}
+
+export interface Team {
+  id: string;
+  name: string;
+  created_by: string;
+  members: TeamMember[] | string[];
+  created_at: string;
+}
+
+export async function listTeams(): Promise<{ teams: Team[] }> {
+  return apiFetch<{ teams: Team[] }>("/teams");
+}
+
+export async function createTeam(name: string): Promise<{ team: Team }> {
+  return apiFetch<{ team: Team }>("/teams", { method: "POST", body: JSON.stringify({ name }) });
+}
+
+export async function getTeam(id: string): Promise<{ team: Team }> {
+  return apiFetch<{ team: Team }>(`/teams/${id}`);
+}
+
+export async function addTeamMember(teamId: string, email: string): Promise<{ ok: boolean }> {
+  return apiFetch<{ ok: boolean }>(`/teams/${teamId}/members`, { method: "POST", body: JSON.stringify({ email }) });
+}
+
+export async function removeTeamMember(teamId: string, userId: string): Promise<{ ok: boolean }> {
+  return apiFetch<{ ok: boolean }>(`/teams/${teamId}/members/${userId}`, { method: "DELETE" });
 }

--- a/cthulu-studio/src/api/interactStream.ts
+++ b/cthulu-studio/src/api/interactStream.ts
@@ -1,4 +1,4 @@
-import { getServerUrl } from "./client";
+import { getServerUrl, getAuthTokenSync } from "./client";
 import { log } from "./logger";
 
 export interface InteractSSEEvent {
@@ -43,9 +43,13 @@ export function startAgentChat(
     body.images = images;
   }
 
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  const token = getAuthTokenSync();
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
   fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify(body),
     signal: controller.signal,
   })
@@ -121,8 +125,13 @@ export function reconnectAgentChat(
   log("http", `GET /agents/${agentId}/sessions/${sessionId}/chat/stream (reconnect)`);
   console.log(`[RECONNECT-DEBUG] interactStream: fetching ${url}`);
 
+  const reconnectHeaders: Record<string, string> = {};
+  const reconnectToken = getAuthTokenSync();
+  if (reconnectToken) reconnectHeaders["Authorization"] = `Bearer ${reconnectToken}`;
+
   fetch(url, {
     method: "GET",
+    headers: reconnectHeaders,
     signal: controller.signal,
   })
     .then(async (response) => {

--- a/cthulu-studio/src/api/runStream.ts
+++ b/cthulu-studio/src/api/runStream.ts
@@ -1,12 +1,12 @@
 import type { RunEvent } from "../types/flow";
-import { getServerUrl } from "./client";
+import { getServerUrl, withAuthToken } from "./client";
 
 export function subscribeToRuns(
   flowId: string,
   onEvent: (event: RunEvent) => void,
   onError?: (err: Event) => void
 ): () => void {
-  const url = `${getServerUrl()}/api/flows/${flowId}/runs/live`;
+  const url = withAuthToken(`${getServerUrl()}/api/flows/${flowId}/runs/live`);
   const es = new EventSource(url);
 
   const eventTypes = [

--- a/cthulu-studio/src/components/AuthGate.tsx
+++ b/cthulu-studio/src/components/AuthGate.tsx
@@ -1,0 +1,176 @@
+import { useState, useCallback, createContext, useContext } from "react";
+import { setAuthTokenGetter, getServerUrl } from "../api/client";
+
+// ── Auth context so any component can call logout ────────────
+
+interface AuthContextValue {
+  logout: () => void;
+  userEmail: string | null;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  logout: () => {},
+  userEmail: null,
+});
+
+/** Hook for any component to access logout + user info. */
+export function useAuth() {
+  return useContext(AuthContext);
+}
+
+interface AuthGateProps {
+  children: React.ReactNode;
+}
+
+/** Decode base64url to string (handles missing padding). */
+function b64urlDecode(str: string): string {
+  const padded = str.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat((4 - (str.length % 4)) % 4);
+  return atob(padded);
+}
+
+/** Parse JWT payload and return claims, or null if unparseable. */
+function parseToken(token: string): { email?: string; exp?: number } | null {
+  try {
+    const payload = token.split(".")[1];
+    return JSON.parse(b64urlDecode(payload));
+  } catch {
+    return null;
+  }
+}
+
+/** Check if token is valid: parseable, has email, not expired. */
+function isTokenValid(token: string): boolean {
+  const claims = parseToken(token);
+  if (!claims?.email) return false;
+  if (claims.exp && claims.exp * 1000 < Date.now()) return false;
+  return true;
+}
+
+/**
+ * Self-hosted auth gate. Shows login/signup when no token,
+ * renders children when authenticated.
+ * When VITE_AUTH_ENABLED is not "true", renders children directly (dev mode).
+ */
+export default function AuthGate({ children }: AuthGateProps) {
+  const authEnabled = import.meta.env.VITE_AUTH_ENABLED === "true";
+
+  // Initialize token AND token getter synchronously to avoid race condition
+  // where children's effects fire API calls before the getter is wired up.
+  const [token, setToken] = useState<string | null>(() => {
+    const t = localStorage.getItem("cthulu_auth_token");
+    if (t && isTokenValid(t)) {
+      setAuthTokenGetter(() => Promise.resolve(t));
+      return t;
+    }
+    // Clear invalid/expired token
+    if (t) localStorage.removeItem("cthulu_auth_token");
+    setAuthTokenGetter(null);
+    return null;
+  });
+
+  const logout = useCallback(() => {
+    localStorage.removeItem("cthulu_auth_token");
+    setAuthTokenGetter(null);
+    setToken(null);
+  }, []);
+
+  if (!authEnabled) return <>{children}</>;
+
+  if (token) {
+    const claims = parseToken(token);
+    return (
+      <AuthContext.Provider value={{ logout, userEmail: claims?.email ?? null }}>
+        {children}
+      </AuthContext.Provider>
+    );
+  }
+
+  return <AuthForm onSuccess={(t) => {
+    localStorage.setItem("cthulu_auth_token", t);
+    setAuthTokenGetter(() => Promise.resolve(t));
+    setToken(t);
+  }} />;
+}
+
+function AuthForm({ onSuccess }: { onSuccess: (token: string) => void }) {
+  const [mode, setMode] = useState<"login" | "signup">("login");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      const endpoint = mode === "signup" ? "/api/auth/signup" : "/api/auth/login";
+      const res = await fetch(`${getServerUrl()}${endpoint}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error || `Failed (${res.status})`);
+        return;
+      }
+
+      onSuccess(data.token);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Network error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-container">
+      <div className="auth-card">
+        <h1 className="auth-title">Cthulu</h1>
+        <p className="auth-subtitle">
+          {mode === "login" ? "Sign in to your account" : "Create a new account"}
+        </p>
+
+        <form onSubmit={handleSubmit} className="auth-form">
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="auth-input"
+            required
+            autoFocus
+          />
+          <input
+            type="password"
+            placeholder="Password (8+ characters)"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="auth-input"
+            required
+            minLength={8}
+          />
+
+          {error && <p className="auth-error">{error}</p>}
+
+          <button type="submit" className="auth-button" disabled={loading}>
+            {loading ? "..." : mode === "login" ? "Sign In" : "Sign Up"}
+          </button>
+        </form>
+
+        <button
+          className="auth-toggle"
+          onClick={() => { setMode(mode === "login" ? "signup" : "login"); setError(""); }}
+        >
+          {mode === "login"
+            ? "Don't have an account? Sign up"
+            : "Already have an account? Sign in"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/cthulu-studio/src/components/Sidebar.tsx
+++ b/cthulu-studio/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { STUDIO_ASSISTANT_ID, type FlowSummary, type Flow, type NodeTypeSchema, type AgentSummary, type SavedPrompt, type ActiveView } from "../types/flow";
-import { listAgents, createAgent, deleteAgent, listPrompts, savePrompt, deletePrompt as deletePromptApi, listAgentSessions, newAgentSession } from "../api/client";
+import { listAgents, createAgent, deleteAgent, listPrompts, savePrompt, deletePrompt as deletePromptApi, listAgentSessions, newAgentSession, listTeams } from "../api/client";
 import type { InteractSessionInfo } from "../api/client";
 import { Switch } from "@/components/ui/switch";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
@@ -66,6 +66,11 @@ export default function Sidebar({
   const [prompts, setPrompts] = useState<SavedPrompt[]>([]);
   const [agentMeta, setAgentMeta] = useState<Map<string, { busy: boolean; sessions: InteractSessionInfo[]; cost: number }>>(new Map());
   const [expandedAgents, setExpandedAgents] = useState<Set<string>>(new Set());
+  const [userTeams, setUserTeams] = useState<{ id: string; name: string }[]>([]);
+
+  useEffect(() => {
+    listTeams().then((res) => setUserTeams(res.teams.map((t) => ({ id: t.id, name: t.name })))).catch(() => {});
+  }, []);
 
   const refreshAgents = useCallback(async () => {
     try {
@@ -153,6 +158,20 @@ export default function Sidebar({
     }
   }
 
+  async function handleCreateTeamAgent(teamId: string) {
+    try {
+      const team = userTeams.find((t) => t.id === teamId);
+      const { id } = await createAgent({
+        name: `${team?.name || "Team"} Agent`,
+        team_id: teamId,
+      });
+      await refreshAgents();
+      onAgentCreated(id);
+    } catch (e) {
+      console.error("Failed to create team agent:", e);
+    }
+  }
+
   async function handleDeleteAgent(e: React.MouseEvent, agentId: string) {
     e.stopPropagation();
     if (!confirm("Delete this agent?")) return;
@@ -219,20 +238,29 @@ export default function Sidebar({
             <span className="sidebar-chevron">▶</span>
             <h2>Agents</h2>
             <div style={{ flex: 1 }} />
-            <button
-              className="ghost sidebar-action-btn"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleCreateAgent();
+            <select
+              className="sidebar-agent-create-select"
+              value=""
+              onClick={(e) => e.stopPropagation()}
+              onChange={(e) => {
+                const val = e.target.value;
+                if (val === "personal") handleCreateAgent();
+                else if (val) handleCreateTeamAgent(val);
+                e.target.value = "";
               }}
             >
-              +
-            </button>
+              <option value="">+</option>
+              <option value="personal">Personal Agent</option>
+              {userTeams.length > 0 && <option disabled>── Teams ──</option>}
+              {userTeams.map((t) => (
+                <option key={t.id} value={t.id}>{t.name} Agent</option>
+              ))}
+            </select>
           </div>
         </CollapsibleTrigger>
         <CollapsibleContent>
           <div className="sidebar-section-body">
-            {[...agents].sort((a, b) => {
+            {[...agents].filter((a) => !a.team_id).sort((a, b) => {
               if (a.id === STUDIO_ASSISTANT_ID) return -1;
               if (b.id === STUDIO_ASSISTANT_ID) return 1;
               return 0;
@@ -318,6 +346,49 @@ export default function Sidebar({
           </div>
         </CollapsibleContent>
       </Collapsible>
+
+      {/* Team Agents — one sub-section per team */}
+      {userTeams.map((team) => {
+        const teamAgents = agents.filter((a) => a.team_id === team.id);
+        return (
+          <Collapsible key={team.id} defaultOpen className="sidebar-section">
+            <CollapsibleTrigger asChild>
+              <div className="sidebar-section-header">
+                <span className="sidebar-chevron">▶</span>
+                <h2 className="sidebar-team-name">
+                  <span className="sidebar-team-badge" />
+                  {team.name}
+                </h2>
+                <div style={{ flex: 1 }} />
+                <button className="ghost sidebar-action-btn"
+                  onClick={(e) => { e.stopPropagation(); handleCreateTeamAgent(team.id); }}>+</button>
+              </div>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="sidebar-section-body">
+                {teamAgents.length === 0 && <div className="sidebar-empty">No agents yet</div>}
+                {teamAgents.map((agent) => {
+                  const meta = agentMeta.get(agent.id);
+                  const isActive = agent.id === selectedAgentId && activeView === "agent-workspace";
+                  return (
+                    <div key={agent.id} className="sb-agent">
+                      <div className={`sb-agent-row sb-agent-team${isActive ? " sb-agent-active" : ""}`}
+                        onClick={() => {
+                          const sessions = meta?.sessions ?? [];
+                          if (sessions.length > 0) onSelectSession(agent.id, sessions[0].session_id);
+                        }}>
+                        <span className="sb-agent-name">{agent.name}</span>
+                        {meta?.busy && <span className="sb-agent-dot sb-agent-busy" />}
+                        <span className="sb-agent-team-tag">team</span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        );
+      })}
 
       {/* Flows section (collapsed by default) */}
       <Collapsible className="sidebar-section">

--- a/cthulu-studio/src/components/TopBar.tsx
+++ b/cthulu-studio/src/components/TopBar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { useAuth } from "./AuthGate";
 import * as api from "../api/client";
 import { log } from "../api/logger";
 import { Button } from "@/components/ui/button";
@@ -249,6 +250,8 @@ export default function TopBar({
       <Button variant="ghost" size="sm" onClick={onSettingsClick}>
         Settings
       </Button>
+
+      <ProfileMenu />
     </div>
   );
 }
@@ -283,5 +286,188 @@ function ThemeSelector() {
         </SelectGroup>
       </SelectContent>
     </Select>
+  );
+}
+
+function ProfileMenu() {
+  const { logout, userEmail } = useAuth();
+  const [open, setOpen] = useState(false);
+  const [profile, setProfile] = useState<{ name: string | null; email: string } | null>(null);
+  const [teams, setTeams] = useState<{ id: string; name: string }[]>([]);
+  const [editingName, setEditingName] = useState(false);
+  const [nameInput, setNameInput] = useState("");
+  const [newTeamName, setNewTeamName] = useState("");
+  const [expandedTeam, setExpandedTeam] = useState<string | null>(null);
+  const [teamMembers, setTeamMembers] = useState<Record<string, { id: string; email: string; name: string | null }[]>>({});
+  const [memberError, setMemberError] = useState("");
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  if (!userEmail) return null;
+
+  const loadData = useCallback(async () => {
+    try {
+      const [p, t] = await Promise.all([api.getProfile(), api.listTeams()]);
+      setProfile({ name: p.name, email: p.email });
+      setTeams(t.teams.map((tm) => ({ id: tm.id, name: tm.name })));
+    } catch { /* ignore if not authed */ }
+  }, []);
+
+  useEffect(() => {
+    if (open) loadData();
+  }, [open, loadData]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const handleSaveName = async () => {
+    if (!nameInput.trim()) return;
+    await api.updateProfile({ name: nameInput.trim() });
+    setProfile((p) => p ? { ...p, name: nameInput.trim() } : p);
+    setEditingName(false);
+  };
+
+  const loadTeamMembers = async (teamId: string) => {
+    const { team } = await api.getTeam(teamId);
+    setTeamMembers((prev) => ({ ...prev, [teamId]: team.members as { id: string; email: string; name: string | null }[] }));
+  };
+
+  const handleExpandTeam = async (teamId: string) => {
+    if (expandedTeam === teamId) { setExpandedTeam(null); return; }
+    setExpandedTeam(teamId);
+    setMemberError("");
+    try { await loadTeamMembers(teamId); } catch { /* ignore */ }
+  };
+
+  const handleRemoveMember = async (teamId: string, userId: string) => {
+    try {
+      await api.removeTeamMember(teamId, userId);
+      await loadTeamMembers(teamId);
+    } catch { /* ignore */ }
+  };
+
+  const handleCreateTeam = async () => {
+    if (!newTeamName.trim()) return;
+    const { team } = await api.createTeam(newTeamName.trim());
+    setTeams((prev) => [...prev, { id: team.id, name: team.name }]);
+    setNewTeamName("");
+  };
+
+  return (
+    <div className="profile-menu" ref={menuRef}>
+      <Button variant="ghost" size="sm" onClick={() => setOpen(!open)}>
+        {profile?.name || userEmail.split("@")[0]}
+      </Button>
+
+      {open && (
+        <div className="profile-dropdown">
+          <div className="profile-section">
+            <div className="profile-label">Profile</div>
+            <div className="profile-email">{profile?.email || userEmail}</div>
+            {editingName ? (
+              <div className="profile-name-edit">
+                <input className="auth-input" value={nameInput} onChange={(e) => setNameInput(e.target.value)}
+                  placeholder="Display name" autoFocus onKeyDown={(e) => e.key === "Enter" && handleSaveName()} />
+                <Button variant="ghost" size="sm" onClick={handleSaveName}>Save</Button>
+              </div>
+            ) : (
+              <button className="profile-name-btn"
+                onClick={() => { setNameInput(profile?.name || ""); setEditingName(true); }}>
+                {profile?.name || "Set display name"}
+              </button>
+            )}
+          </div>
+
+          <div className="profile-divider" />
+
+          <div className="profile-section">
+            <div className="profile-label">Teams</div>
+            {teams.length === 0 && <div className="profile-empty">No teams yet</div>}
+            {teams.map((t) => (
+              <div key={t.id} className="profile-team-card">
+                <button className="profile-team-header" onClick={() => handleExpandTeam(t.id)}>
+                  <span>{t.name}</span>
+                  <span className="profile-team-chevron">{expandedTeam === t.id ? "▾" : "▸"}</span>
+                </button>
+                {expandedTeam === t.id && (
+                  <div className="profile-team-body">
+                    {(teamMembers[t.id] || []).map((m) => (
+                      <div key={m.id} className="profile-member">
+                        <span className="profile-member-info">
+                          <span className="profile-member-name">{m.name || m.email.split("@")[0]}</span>
+                          <span className="profile-member-email">{m.email}</span>
+                        </span>
+                        <button className="profile-member-remove" onClick={() => handleRemoveMember(t.id, m.id)} title="Remove member">x</button>
+                      </div>
+                    ))}
+                    <UserSearchInput onSelect={async (_userId, email) => {
+                      try {
+                        await api.addTeamMember(t.id, email);
+                        await loadTeamMembers(t.id);
+                      } catch (e) { setMemberError(e instanceof Error ? e.message : "Failed"); }
+                    }} />
+                    {memberError && <div className="auth-error" style={{ padding: "2px 0" }}>{memberError}</div>}
+                  </div>
+                )}
+              </div>
+            ))}
+            <div className="profile-name-edit">
+              <input className="auth-input" value={newTeamName} onChange={(e) => setNewTeamName(e.target.value)}
+                placeholder="New team name" onKeyDown={(e) => e.key === "Enter" && handleCreateTeam()} />
+              <Button variant="ghost" size="sm" onClick={handleCreateTeam}>Create</Button>
+            </div>
+          </div>
+
+          <div className="profile-divider" />
+          <button className="profile-signout" onClick={logout}>Sign Out</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UserSearchInput({ onSelect }: { onSelect: (userId: string, email: string) => void }) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<api.UserSearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleChange = (value: string) => {
+    setQuery(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (value.trim().length < 2) { setResults([]); return; }
+
+    setSearching(true);
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const { users } = await api.searchUsers(value.trim());
+        setResults(users);
+      } catch { setResults([]); }
+      finally { setSearching(false); }
+    }, 300);
+  };
+
+  return (
+    <div className="user-search">
+      <input className="auth-input" placeholder="Add member (search name or email)"
+        value={query} onChange={(e) => handleChange(e.target.value)} />
+      {(results.length > 0 || searching) && (
+        <div className="user-search-results">
+          {searching && <div className="user-search-item user-search-loading">Searching...</div>}
+          {results.map((u) => (
+            <button key={u.id} className="user-search-item"
+              onClick={() => { onSelect(u.id, u.email); setQuery(""); setResults([]); }}>
+              <span className="user-search-name">{u.name || u.email.split("@")[0]}</span>
+              <span className="user-search-email">{u.email}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/cthulu-studio/src/components/chat/useAgentChat.ts
+++ b/cthulu-studio/src/components/chat/useAgentChat.ts
@@ -79,6 +79,15 @@ function applySSEEvent(
         setGitSnapshot(data as MultiRepoSnapshot);
       }
       return false;
+    } else if (event.type === "user_message") {
+      // Team session: another user sent a message — show attribution
+      const sender = data.user_id || "unknown";
+      const text = data.text || "";
+      partsRef.current = [...partsRef.current, {
+        type: "text",
+        text: `[${sender}]: ${text}`,
+      }];
+      return true;
     } else if (event.type === "result") {
       const hasText = partsRef.current.some((p) => p.type === "text");
       if (data.text && !hasText) {

--- a/cthulu-studio/src/styles.css
+++ b/cthulu-studio/src/styles.css
@@ -1,6 +1,180 @@
 @import "tailwindcss";
 @import "tw-shimmer";
 
+/* ── Auth Gate ────────────────────────────────────────────────── */
+.auth-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: var(--bg);
+}
+.auth-card {
+  width: 360px;
+  padding: 32px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.auth-title {
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--text);
+  text-align: center;
+  margin-bottom: 4px;
+}
+.auth-subtitle {
+  font-size: 13px;
+  color: var(--text-secondary);
+  text-align: center;
+  margin-bottom: 24px;
+}
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.auth-input {
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.15s;
+  box-sizing: border-box;
+}
+.auth-input:focus { border-color: var(--accent); }
+.auth-input::placeholder { color: var(--text-secondary); opacity: 0.7; }
+.auth-button {
+  width: 100%;
+  padding: 10px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.auth-button:hover { opacity: 0.9; }
+.auth-button:disabled { opacity: 0.5; cursor: not-allowed; }
+.auth-error {
+  color: #ef4444;
+  font-size: 12px;
+  margin: 0;
+}
+.auth-toggle {
+  display: block;
+  width: 100%;
+  margin-top: 16px;
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 12px;
+  cursor: pointer;
+  text-align: center;
+}
+.auth-toggle:hover { text-decoration: underline; }
+
+/* ── Profile Menu ─────────────────────────────────────────────── */
+.profile-menu { position: relative; }
+.profile-dropdown {
+  position: absolute; top: calc(100% + 4px); right: 0; width: 300px;
+  max-height: 80vh; overflow-y: auto; background: var(--bg-secondary);
+  border: 1px solid var(--border); border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.25); z-index: 200; padding: 8px 0;
+}
+.profile-section { padding: 8px 14px; }
+.profile-label {
+  font-size: 10px; font-weight: 600; text-transform: uppercase;
+  letter-spacing: 0.5px; color: var(--text-secondary); margin-bottom: 6px;
+}
+.profile-email { font-size: 12px; color: var(--text); margin-bottom: 4px; }
+.profile-name-btn {
+  display: block; background: none; border: none; color: var(--accent);
+  font-size: 12px; cursor: pointer; padding: 0;
+}
+.profile-name-btn:hover { text-decoration: underline; }
+.profile-name-edit { display: flex; gap: 4px; align-items: center; margin-top: 4px; }
+.profile-name-edit .auth-input { flex: 1; padding: 5px 8px; font-size: 12px; }
+.profile-divider { height: 1px; background: var(--border); margin: 4px 0; }
+.profile-empty { font-size: 12px; color: var(--text-secondary); font-style: italic; padding: 2px 0; }
+.profile-signout {
+  display: block; width: 100%; padding: 8px 14px; background: none;
+  border: none; color: #ef4444; font-size: 12px; text-align: left; cursor: pointer;
+}
+.profile-signout:hover { background: var(--bg); }
+
+/* ── Team Card + Members ──────────────────────────────────────── */
+.profile-team-card { border: 1px solid var(--border); border-radius: 6px; margin-bottom: 6px; overflow: visible; }
+.profile-team-header {
+  display: flex; align-items: center; justify-content: space-between; width: 100%;
+  padding: 6px 10px; background: var(--bg); border: none; color: var(--text);
+  font-size: 12px; font-weight: 500; cursor: pointer; text-align: left;
+}
+.profile-team-header:hover { background: color-mix(in srgb, var(--accent) 8%, var(--bg)); }
+.profile-team-chevron { color: var(--text-secondary); font-size: 10px; }
+.profile-team-body { padding: 6px 10px; }
+.profile-member { display: flex; align-items: center; justify-content: space-between; padding: 3px 0; gap: 6px; }
+.profile-member-info { display: flex; flex-direction: column; min-width: 0; }
+.profile-member-name { font-size: 12px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.profile-member-email { font-size: 10px; color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.profile-member-remove {
+  background: none; border: none; color: var(--text-secondary); cursor: pointer;
+  font-size: 11px; padding: 2px 4px; border-radius: 3px; flex-shrink: 0;
+}
+.profile-member-remove:hover { color: #ef4444; background: color-mix(in srgb, #ef4444 10%, transparent); }
+
+/* ── User Search Picker ───────────────────────────────────────── */
+.user-search { margin-top: 6px; }
+.user-search .auth-input { font-size: 11px; padding: 5px 8px; }
+.user-search-results {
+  background: var(--bg); border: 1px solid var(--border); border-radius: 4px;
+  margin-top: 4px; max-height: 150px; overflow-y: auto;
+}
+.user-search-item {
+  display: flex; align-items: center; gap: 8px; width: 100%; padding: 6px 10px;
+  background: none; border: none; color: var(--text); font-size: 12px; cursor: pointer; text-align: left;
+}
+.user-search-item:hover { background: var(--bg-secondary); }
+.user-search-loading { color: var(--text-secondary); font-style: italic; cursor: default; }
+.user-search-name { font-weight: 500; }
+.user-search-email { color: var(--text-secondary); font-size: 10px; }
+
+/* ── Agent Create Picker ──────────────────────────────────────── */
+.sidebar-agent-create-select {
+  background: transparent; border: none; color: var(--text-secondary);
+  font-size: 14px; font-weight: 500; cursor: pointer; padding: 0 2px;
+  outline: none; -webkit-appearance: none; appearance: none; width: 20px; text-align: center;
+}
+.sidebar-agent-create-select:hover { color: var(--text); }
+.sidebar-agent-create-select option {
+  background: var(--bg-secondary); color: var(--text); font-size: 12px; padding: 4px 8px;
+}
+.sidebar-agent-create-select option:disabled { color: var(--text-secondary); font-size: 10px; }
+
+/* ── Team Agents Visual Distinction ───────────────────────────── */
+.sidebar-team-badge {
+  display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); margin-right: 6px; flex-shrink: 0;
+}
+.sidebar-team-name { display: flex; align-items: center; }
+.sb-agent-team { border-left: 2px solid var(--accent); padding-left: 8px; }
+.sb-agent-team-tag {
+  font-size: 9px; text-transform: uppercase; letter-spacing: 0.5px;
+  color: var(--accent); background: color-mix(in srgb, var(--accent) 12%, transparent);
+  padding: 1px 5px; border-radius: 3px; margin-left: auto; flex-shrink: 0;
+}
+.sidebar-empty {
+  font-size: 11px; color: var(--text-secondary); font-style: italic; padding: 4px 12px;
+}
+
 /* ── Register shadcn color tokens for Tailwind v4 ──────────────────────
    Maps Tailwind utility names (bg-popover, text-muted-foreground, etc.)
    to our :root CSS variables. Without this, bg-popover etc. are transparent. */

--- a/cthulu-studio/src/types/flow.ts
+++ b/cthulu-studio/src/types/flow.ts
@@ -135,6 +135,7 @@ export interface Agent {
   permissions: string[];
   append_system_prompt: string | null;
   working_dir: string | null;
+  team_id: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -146,6 +147,7 @@ export interface AgentSummary {
   permissions: string[];
   subagent_only?: boolean;
   subagent_count?: number;
+  team_id?: string | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary

Depends on: #121 (profile + teams UI) — merge that first.

- Add `team_id` field to Agent struct — team-owned agents
- Team membership check on chat endpoint (403 for non-members)
- Broadcast `user_message` SSE event with sender attribution
- Frontend handles `user_message` event in chat stream
- Sidebar splits agents into "Agents" (personal) + per-team sections
- Agent create picker: "+" dropdown offers Personal Agent or Team Agent
- Visual distinction: accent border + "team" badge on team agents

## How It Works

1. Create a team agent via "+" picker (select a team)
2. All team members see it in their team's sidebar section
3. Any member sends a message — `user_message` event broadcasts
4. Other members join via reconnect endpoint (spectate in real-time)
5. One sender at a time (existing 409 while busy)

## Files changed (7 files, ~146 lines)
- `agents/mod.rs` — `team_id` field on Agent
- `chat.rs` — AuthUser extractor, team check, user_message broadcast
- `Sidebar.tsx` — team sections + agent create picker
- `useAgentChat.ts` — handle `user_message` SSE event
- `flow.ts` — `team_id` on Agent/AgentSummary types
- `client.ts` — `team_id` on createAgent
- `styles.css` — team agent visual styles

## Verification
- `cargo check` — 0 errors
- `cargo test` — 319 passed
- `npx nx build cthulu-studio` — builds clean

## Dependency chain
**PR F (6/6)** — final PR, merge after #121

```
main → #117 → #118 → #119 + #120 → #121 → THIS PR F (team sessions)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)