### PR TITLE
feat: wrap App in AuthGate + auth CSS

### DIFF
--- a/cthulu-studio/src/App.tsx
+++ b/cthulu-studio/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import AuthGate from "./components/AuthGate";
 import * as api from "./api/client";
 import { log } from "./api/logger";
 import { subscribeToRuns } from "./api/runStream";
@@ -318,6 +319,7 @@ export default function App() {
   };
 
   return (
+    <AuthGate>
     <div className="app">
       <TopBar
         activeView={activeView}
@@ -457,5 +459,6 @@ export default function App() {
         </DialogContent>
       </Dialog>
     </div>
+    </AuthGate>
   );
 }

--- a/cthulu-studio/src/api/client.ts
+++ b/cthulu-studio/src/api/client.ts
@@ -37,6 +37,39 @@ export function getServerUrl(): string {
   return getBaseUrl();
 }
 
+// ── Auth token injection ─────────────────────────────────────
+
+let getTokenFn: (() => Promise<string | null>) | null = null;
+
+/** Called by AuthGate to wire token getter into all API requests. */
+export function setAuthTokenGetter(fn: (() => Promise<string | null>) | null) {
+  getTokenFn = fn;
+}
+
+/** Get the current auth token (if available). Used by SSE EventSource callers. */
+export async function getAuthToken(): Promise<string | null> {
+  return getTokenFn ? getTokenFn() : null;
+}
+
+/** Get auth token synchronously from localStorage (for EventSource URLs). */
+export function getAuthTokenSync(): string | null {
+  return localStorage.getItem("cthulu_auth_token");
+}
+
+/** Append ?token= to a URL for EventSource connections (which can't set headers). */
+export function withAuthToken(url: string): string {
+  const token = getAuthTokenSync();
+  if (!token) return url;
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}token=${encodeURIComponent(token)}`;
+}
+
+/** Get auth headers for fetch-based streaming (non-apiFetch callers). */
+export async function getAuthHeaders(): Promise<Record<string, string>> {
+  const token = await getAuthToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 async function apiFetch<T>(
   path: string,
   options: RequestInit = {}
@@ -47,11 +80,21 @@ async function apiFetch<T>(
   log("http", `${method} ${path}`);
   const start = performance.now();
 
+  // Attach auth token if available
+  const authHeaders: Record<string, string> = {};
+  if (getTokenFn) {
+    const token = await getTokenFn();
+    if (token) {
+      authHeaders["Authorization"] = `Bearer ${token}`;
+    }
+  }
+
   try {
     const res = await fetch(url, {
       ...options,
       headers: {
         "Content-Type": "application/json",
+        ...authHeaders,
         ...options.headers,
       },
     });
@@ -59,6 +102,11 @@ async function apiFetch<T>(
     const elapsed = Math.round(performance.now() - start);
 
     if (!res.ok) {
+      // Auto-logout on 401 (expired/invalid token)
+      if (res.status === 401 && getTokenFn) {
+        localStorage.removeItem("cthulu_auth_token");
+        window.location.reload();
+      }
       const body = await res.text();
       log("error", `${method} ${path} -> ${res.status} (${elapsed}ms)`, body);
       throw new Error(`API error ${res.status}: ${body}`);
@@ -326,7 +374,7 @@ export function streamSessionLog(
   onLine: (line: string) => void,
   onDone: () => void
 ): () => void {
-  const url = `${getBaseUrl()}/api/agents/${agentId}/sessions/${sessionId}/stream`;
+  const url = withAuthToken(`${getBaseUrl()}/api/agents/${agentId}/sessions/${sessionId}/stream`);
   const source = new EventSource(url);
 
   source.addEventListener("line", (e: MessageEvent) => {
@@ -540,6 +588,7 @@ export async function createAgent(data: {
   permissions?: string[];
   append_system_prompt?: string | null;
   working_dir?: string | null;
+  team_id?: string | null;
 }): Promise<{ id: string }> {
   return apiFetch<{ id: string }>("/agents", {
     method: "POST",
@@ -586,7 +635,7 @@ export interface ResourceChangeEvent {
 export function subscribeToChanges(
   onEvent: (event: ResourceChangeEvent) => void
 ): () => void {
-  const url = `${getBaseUrl()}/api/changes`;
+  const url = withAuthToken(`${getBaseUrl()}/api/changes`);
   const source = new EventSource(url);
 
   const handler = (e: MessageEvent) => {
@@ -706,4 +755,68 @@ export async function getDashboardSummary(
     method: "POST",
     body: JSON.stringify({ channels }),
   });
+}
+
+// ── Profile ──────────────────────────────────────────────────
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  name: string | null;
+  avatar_url: string | null;
+  created_at: string;
+}
+
+export async function getProfile(): Promise<UserProfile> {
+  return apiFetch<UserProfile>("/auth/me");
+}
+
+export async function updateProfile(data: { name?: string; avatar_url?: string }): Promise<UserProfile> {
+  return apiFetch<UserProfile>("/auth/me", { method: "PUT", body: JSON.stringify(data) });
+}
+
+export interface UserSearchResult {
+  id: string;
+  email: string;
+  name: string | null;
+}
+
+export async function searchUsers(query: string): Promise<{ users: UserSearchResult[] }> {
+  return apiFetch<{ users: UserSearchResult[] }>(`/auth/users/search?q=${encodeURIComponent(query)}`);
+}
+
+// ── Teams ────────────────────────────────────────────────────
+
+export interface TeamMember {
+  id: string;
+  email: string;
+  name: string | null;
+}
+
+export interface Team {
+  id: string;
+  name: string;
+  created_by: string;
+  members: TeamMember[] | string[];
+  created_at: string;
+}
+
+export async function listTeams(): Promise<{ teams: Team[] }> {
+  return apiFetch<{ teams: Team[] }>("/teams");
+}
+
+export async function createTeam(name: string): Promise<{ team: Team }> {
+  return apiFetch<{ team: Team }>("/teams", { method: "POST", body: JSON.stringify({ name }) });
+}
+
+export async function getTeam(id: string): Promise<{ team: Team }> {
+  return apiFetch<{ team: Team }>(`/teams/${id}`);
+}
+
+export async function addTeamMember(teamId: string, email: string): Promise<{ ok: boolean }> {
+  return apiFetch<{ ok: boolean }>(`/teams/${teamId}/members`, { method: "POST", body: JSON.stringify({ email }) });
+}
+
+export async function removeTeamMember(teamId: string, userId: string): Promise<{ ok: boolean }> {
+  return apiFetch<{ ok: boolean }>(`/teams/${teamId}/members/${userId}`, { method: "DELETE" });
 }

--- a/cthulu-studio/src/components/AuthGate.tsx
+++ b/cthulu-studio/src/components/AuthGate.tsx
@@ -1,0 +1,176 @@
+import { useState, useCallback, createContext, useContext } from "react";
+import { setAuthTokenGetter, getServerUrl } from "../api/client";
+
+// ── Auth context so any component can call logout ────────────
+
+interface AuthContextValue {
+  logout: () => void;
+  userEmail: string | null;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  logout: () => {},
+  userEmail: null,
+});
+
+/** Hook for any component to access logout + user info. */
+export function useAuth() {
+  return useContext(AuthContext);
+}
+
+interface AuthGateProps {
+  children: React.ReactNode;
+}
+
+/** Decode base64url to string (handles missing padding). */
+function b64urlDecode(str: string): string {
+  const padded = str.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat((4 - (str.length % 4)) % 4);
+  return atob(padded);
+}
+
+/** Parse JWT payload and return claims, or null if unparseable. */
+function parseToken(token: string): { email?: string; exp?: number } | null {
+  try {
+    const payload = token.split(".")[1];
+    return JSON.parse(b64urlDecode(payload));
+  } catch {
+    return null;
+  }
+}
+
+/** Check if token is valid: parseable, has email, not expired. */
+function isTokenValid(token: string): boolean {
+  const claims = parseToken(token);
+  if (!claims?.email) return false;
+  if (claims.exp && claims.exp * 1000 < Date.now()) return false;
+  return true;
+}
+
+/**
+ * Self-hosted auth gate. Shows login/signup when no token,
+ * renders children when authenticated.
+ * When VITE_AUTH_ENABLED is not "true", renders children directly (dev mode).
+ */
+export default function AuthGate({ children }: AuthGateProps) {
+  const authEnabled = import.meta.env.VITE_AUTH_ENABLED === "true";
+
+  // Initialize token AND token getter synchronously to avoid race condition
+  // where children's effects fire API calls before the getter is wired up.
+  const [token, setToken] = useState<string | null>(() => {
+    const t = localStorage.getItem("cthulu_auth_token");
+    if (t && isTokenValid(t)) {
+      setAuthTokenGetter(() => Promise.resolve(t));
+      return t;
+    }
+    // Clear invalid/expired token
+    if (t) localStorage.removeItem("cthulu_auth_token");
+    setAuthTokenGetter(null);
+    return null;
+  });
+
+  const logout = useCallback(() => {
+    localStorage.removeItem("cthulu_auth_token");
+    setAuthTokenGetter(null);
+    setToken(null);
+  }, []);
+
+  if (!authEnabled) return <>{children}</>;
+
+  if (token) {
+    const claims = parseToken(token);
+    return (
+      <AuthContext.Provider value={{ logout, userEmail: claims?.email ?? null }}>
+        {children}
+      </AuthContext.Provider>
+    );
+  }
+
+  return <AuthForm onSuccess={(t) => {
+    localStorage.setItem("cthulu_auth_token", t);
+    setAuthTokenGetter(() => Promise.resolve(t));
+    setToken(t);
+  }} />;
+}
+
+function AuthForm({ onSuccess }: { onSuccess: (token: string) => void }) {
+  const [mode, setMode] = useState<"login" | "signup">("login");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      const endpoint = mode === "signup" ? "/api/auth/signup" : "/api/auth/login";
+      const res = await fetch(`${getServerUrl()}${endpoint}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error || `Failed (${res.status})`);
+        return;
+      }
+
+      onSuccess(data.token);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Network error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-container">
+      <div className="auth-card">
+        <h1 className="auth-title">Cthulu</h1>
+        <p className="auth-subtitle">
+          {mode === "login" ? "Sign in to your account" : "Create a new account"}
+        </p>
+
+        <form onSubmit={handleSubmit} className="auth-form">
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="auth-input"
+            required
+            autoFocus
+          />
+          <input
+            type="password"
+            placeholder="Password (8+ characters)"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="auth-input"
+            required
+            minLength={8}
+          />
+
+          {error && <p className="auth-error">{error}</p>}
+
+          <button type="submit" className="auth-button" disabled={loading}>
+            {loading ? "..." : mode === "login" ? "Sign In" : "Sign Up"}
+          </button>
+        </form>
+
+        <button
+          className="auth-toggle"
+          onClick={() => { setMode(mode === "login" ? "signup" : "login"); setError(""); }}
+        >
+          {mode === "login"
+            ? "Don't have an account? Sign up"
+            : "Already have an account? Sign in"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/cthulu-studio/src/styles.css
+++ b/cthulu-studio/src/styles.css
@@ -1,6 +1,47 @@
 @import "tailwindcss";
 @import "tw-shimmer";
 
+/* ── Auth Gate ────────────────────────────────────────────────── */
+.auth-container {
+  display: flex; align-items: center; justify-content: center;
+  height: 100vh; background: var(--bg);
+}
+.auth-card {
+  width: 360px; padding: 32px; background: var(--bg-secondary);
+  border: 1px solid var(--border); border-radius: 8px;
+}
+.auth-title {
+  font-size: 24px; font-weight: 600; color: var(--text);
+  text-align: center; margin-bottom: 4px;
+}
+.auth-subtitle {
+  font-size: 13px; color: var(--text-secondary);
+  text-align: center; margin-bottom: 24px;
+}
+.auth-form { display: flex; flex-direction: column; gap: 12px; }
+.auth-input {
+  width: 100%; padding: 10px 12px; background: var(--bg);
+  border: 1px solid var(--border); border-radius: 6px; color: var(--text);
+  font-size: 13px; font-family: inherit; outline: none;
+  transition: border-color 0.15s; box-sizing: border-box;
+}
+.auth-input:focus { border-color: var(--accent); }
+.auth-input::placeholder { color: var(--text-secondary); opacity: 0.7; }
+.auth-button {
+  width: 100%; padding: 10px; background: var(--accent); color: #fff;
+  border: none; border-radius: 6px; font-size: 13px; font-weight: 500;
+  cursor: pointer; transition: opacity 0.15s;
+}
+.auth-button:hover { opacity: 0.9; }
+.auth-button:disabled { opacity: 0.5; cursor: not-allowed; }
+.auth-error { color: #ef4444; font-size: 12px; margin: 0; }
+.auth-toggle {
+  display: block; width: 100%; margin-top: 16px; padding: 0;
+  background: none; border: none; color: var(--accent);
+  font-size: 12px; cursor: pointer; text-align: center;
+}
+.auth-toggle:hover { text-decoration: underline; }
+
 /* ── Register shadcn color tokens for Tailwind v4 ──────────────────────
    Maps Tailwind utility names (bg-popover, text-muted-foreground, etc.)
    to our :root CSS variables. Without this, bg-popover etc. are transparent. */


### PR DESCRIPTION
## Summary
- Wrap root `App` in `<AuthGate>` (gated by `VITE_AUTH_ENABLED`)
- Auth CSS: login form container, card, inputs, button, toggle

Depends on: #123

## Files (2)
- `cthulu-studio/src/App.tsx` (+3 lines)
- `cthulu-studio/src/styles.css` (+41 lines auth CSS)

## Verification
- `npx nx build cthulu-studio` — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)