### PR TITLE
fix: Slack message fetch timeout (504)

### DIFF
--- a/cthulu-backend/api/dashboard/handlers.rs
+++ b/cthulu-backend/api/dashboard/handlers.rs
@@ -17,8 +17,8 @@ use tokio::process::Command;
 use crate::api::AppState;
 
 /// Timeout for the Python sidecar (Slack message fetching).
-/// 60s to account for --with-threads: each threaded message incurs an API call + 0.4s sleep.
-const SIDECAR_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+/// 120s to account for --with-threads: each threaded message incurs an API call + rate-limit sleep.
+const SIDECAR_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 /// Timeout for the Claude CLI (AI summary generation).
 const CLAUDE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
@@ -595,8 +595,8 @@ mod tests {
 
     #[test]
     fn timeout_constants_are_reasonable() {
-        assert!(SIDECAR_TIMEOUT.as_secs() >= 30, "sidecar timeout too short for threaded fetches");
-        assert!(SIDECAR_TIMEOUT.as_secs() <= 120, "sidecar timeout too long");
+        assert!(SIDECAR_TIMEOUT.as_secs() >= 60, "sidecar timeout too short for threaded fetches");
+        assert!(SIDECAR_TIMEOUT.as_secs() <= 180, "sidecar timeout too long");
         assert!(CLAUDE_TIMEOUT.as_secs() >= 60, "claude timeout too short");
         assert!(CLAUDE_TIMEOUT.as_secs() <= 300, "claude timeout too long");
     }

--- a/scripts/slack_messages.py
+++ b/scripts/slack_messages.py
@@ -141,7 +141,7 @@ class SlackFetcher:
             except (SlackApiError, RuntimeError) as e:
                 print(f"  Skipping {name}: {e}", file=sys.stderr)
                 continue
-            time.sleep(0.4)
+            time.sleep(0.2)
 
             msgs = resp.get("messages", [])
             if resp.get("has_more", False):
@@ -193,7 +193,7 @@ class SlackFetcher:
                         }
                         for r in raw_replies
                     ]
-                    time.sleep(0.4)
+                    time.sleep(0.2)
                 formatted.append(msg_data)
             results.append({
                 "channel": name,


### PR DESCRIPTION
## Summary
- Bump sidecar timeout from 60s → 120s
- Reduce rate-limit sleep from 0.4s → 0.2s per API call

## Problem
Channels with many threaded messages cause the Python sidecar to exceed the 60s timeout. Each thread reply = 1 API call + 0.4s sleep. 50+ threads = 20s+ of sleep alone.

## Fix
- `handlers.rs`: `SIDECAR_TIMEOUT` 60s → 120s
- `slack_messages.py`: `time.sleep(0.4)` → `time.sleep(0.2)` (safe for Slack tier 3 rate limits)
- Net ~3x more throughput within the time budget

## Files (2)
- `cthulu-backend/api/dashboard/handlers.rs`
- `scripts/slack_messages.py`

## Verification
- `cargo check` — 0 errors
- `cargo test timeout_constants` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)